### PR TITLE
feat: Record and report base checkpoint

### DIFF
--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -58,6 +58,9 @@
                     "format": "double",
                     "type": "number"
                 },
+                "baseCheckpoint": {
+                    "type": "string"
+                },
                 "blockSpeed": {
                     "format": "double",
                     "type": "number"
@@ -94,7 +97,8 @@
                 "utxoSpeed",
                 "blockSpeed",
                 "currentEra",
-                "currentMerkleRoot"
+                "currentMerkleRoot",
+                "baseCheckpoint"
             ],
             "type": "object"
         }

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
@@ -2,11 +2,14 @@ module Cardano.UTxOCSMT.Application.Database.Implementation.Query
     ( mkQuery
     , mkTransactionedQuery
     , getAllMerkleRoots
+    , putBaseCheckpoint
+    , getBaseCheckpoint
     )
 where
 
 import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     ( Columns (..)
+    , ConfigKey (..)
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.RollbackPoint
     ( RollbackPoint (..)
@@ -28,6 +31,7 @@ import Database.KV.Cursor
     )
 import Database.KV.Transaction
     ( Transaction
+    , insert
     , iterating
     , query
     )
@@ -85,3 +89,12 @@ getAllMerkleRoots =
                 Entry{entryKey, entryValue = RollbackPoint{rbpHash, rpbMerkleRoot}} -> do
                     rest <- prevEntry >>= go
                     pure $ (entryKey, rbpHash, rpbMerkleRoot) : rest
+
+getBaseCheckpoint
+    :: Transaction m cf (Columns slot hash key value) op (Maybe slot)
+getBaseCheckpoint = query ConfigCol BaseCheckpointKey
+
+putBaseCheckpoint
+    :: slot
+    -> Transaction m cf (Columns slot hash key value) op ()
+putBaseCheckpoint = insert ConfigCol BaseCheckpointKey

--- a/test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
+++ b/test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
@@ -247,6 +247,7 @@ sampleMetrics =
         , blockSpeed = 0.0
         , currentEra = Nothing
         , currentMerkleRoot = Nothing
+        , baseCheckpoint = Nothing
         }
 
 session


### PR DESCRIPTION

## Summary
Implements comprehensive base checkpoint tracking and reporting for the UTxO set.

## Changes

### Database Layer
- Added ConfigCol column family to store configuration data
- New ConfigKey type with BaseCheckpointKey for checkpoint storage
- Implemented getBaseCheckpoint/putBaseCheckpoint queries to persist/retrieve base checkpoint

### Metrics & Reporting
- Extended MetricsEvent with BaseCheckpointEvent
- Added baseCheckpoint field to Metrics struct
- Added renderPoint utility function for consistent Point display
- Updated Swagger schema to include baseCheckpoint in metrics endpoint
- Base checkpoint now exposed via HTTP metrics API

### Application Logic
- Refactored application function signature to accept individual parameters instead of Options record
- Enhanced setupDB to load or initialize base checkpoint on startup
- Updated main trace reporting to display base checkpoint point when DB is not empty
- Modified metrics event extraction to capture both merkle roots and base checkpoint events

### Dependencies
- Added EventQueueLength import in Application.hs
- Added NetworkMagic and PortNumber imports for type clarity

## Files Modified
- application/Cardano/UTxOCSMT/Application/Run/Application.hs
- application/Cardano/UTxOCSMT/Application/Run/Main.hs
- docs/assets/swagger.json
- lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs
- lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
- lib/Cardano/UTxOCSMT/Application/Metrics.hs
- test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs