### PR TITLE
chore: bump haskell-csmt and add rocksdb-kv-transactions dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,8 +20,14 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/paolino/haskell-csmt
-  tag: 455153cb6cf9fe1732bef3885d590873c09abd63
-  --sha256: sha256-WTCzPMZcxQoQrOuESRbO6Qc6AeB5md0ZJZrLxQO4OI8=
+  tag: e33d7110ca9e708f367ca19c69020fc853be4980
+  --sha256: sha256-krDEh3RM6ZJ5c4BMdbFd3/UX2TX5x/rafUmz/vpR/XA=
+
+source-repository-package
+  type: git
+  location: https://github.com/paolino/rocksdb-kv-transactions
+  tag: 2e151146f8bddcbc2ae694e451692e5c51b337ac
+  --sha256: sha256-hhgKUAApaBw2YBBLGqjgj8ZP1tbfAWuqRi1AJcez2jE=
 
 source-repository-package
   type: git

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -103,7 +103,7 @@ library application
     , containers
     , contra-tracer
     , csmt
-    , csmt:kv-transactions
+    , rocksdb-kv-transactions:kv-transactions
     , lens
     , memory
     , mtl
@@ -168,8 +168,8 @@ library library
     , comonad
     , contra-tracer
     , csmt
-    , csmt:kv-transactions
-    , csmt:rocksdb-kv-transactions
+    , rocksdb-kv-transactions:kv-transactions
+    , rocksdb-kv-transactions
     , exceptions
     , foldl
     , lens
@@ -254,7 +254,7 @@ test-suite unit-tests
     , cereal
     , contra-tracer
     , csmt
-    , csmt:kv-transactions
+    , rocksdb-kv-transactions:kv-transactions
     , hspec
     , http-types
     , lens

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs
@@ -22,7 +22,7 @@ import Database.KV.Transaction
     , GEq (..)
     , GOrdering (..)
     , KV
-    , mkCols
+    , fromList
     )
 
 -- | Keys for the configuration column
@@ -85,7 +85,7 @@ codecs
     :: Prisms slot hash key value
     -> DMap (Columns slot hash key value) Codecs
 codecs Prisms{keyP, hashP, slotP, valueP} =
-    mkCols
+    fromList
         [ KVCol :=> Codecs{keyCodec = keyP, valueCodec = valueP}
         , CSMTCol :=> csmtCodecs hashP
         , RollbackPoints


### PR DESCRIPTION
## Summary
- Update haskell-csmt to latest commit with improved documentation and function naming
- Add rocksdb-kv-transactions as separate source-repository-package (kv-transactions was extracted from csmt)
- Update cabal dependencies to use new package structure
- Fix API change: `mkCols` → `fromList`

## Test plan
- [x] `cabal build all` succeeds
- [x] `cabal test all` passes (32 tests)