### PR TITLE
feat: skip block fetch until Mithril slot during bootstrap

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Application.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Application.hs
@@ -42,6 +42,7 @@ import Data.Tracer.TraceWith
     , pattern TraceWith
     )
 import Data.Void (Void)
+import Ouroboros.Network.Block (SlotNo)
 import Ouroboros.Network.Block qualified as Network
 import Ouroboros.Network.Magic (NetworkMagic)
 import Ouroboros.Network.PeerSelection.RelayAccessPoint (PortNumber)
@@ -166,6 +167,10 @@ application
     -- ^ Starting point
     -> EventQueueLength
     -- ^ Headers queue size
+    -> (Point -> IO ())
+    -- ^ Action to set the base checkpoint
+    -> Maybe SlotNo
+    -- ^ Optional skip until slot for Mithril bootstrap
     -> Tracer IO MetricsEvent
     -- ^ Tracer for metrics events
     -> Tracer IO ApplicationTrace
@@ -183,6 +188,8 @@ application
     portNumber
     startingPoint
     headersQueueSize
+    setCheckpoint
+    mSkipTargetSlot
     TraceWith{trace = metricTrace, contra = metricContra}
     TraceWith{tracer}
     initialDBUpdate
@@ -197,6 +204,8 @@ application
                 mkBlockFetchApplication
                     headersQueueSize
                     (metricContra BlockFetchEvent)
+                    setCheckpoint
+                    mSkipTargetSlot
                     $ intersector tracer counting mFinality
                     $ Syncing initialDBUpdate
             let chainFollowingApplication =

--- a/test/Cardano/UTxOCSMT/Mithril/ClientSpec.hs
+++ b/test/Cardano/UTxOCSMT/Mithril/ClientSpec.hs
@@ -105,7 +105,7 @@ spec = describe "Mithril Client E2E" $ do
                                                 fail
                                                     $ "Extraction failed: "
                                                         ++ show err
-                                            Right (count, decoded) -> do
+                                            Right ((count, decoded), _slot) -> do
                                                 -- Preview should have UTxOs
                                                 count `shouldSatisfy` (> 0)
                                                 -- All sampled TxIns should


### PR DESCRIPTION
## Summary

- Skip fetching blocks until reaching the Mithril snapshot slot during bootstrap
- Avoids unnecessary block processing when starting from Mithril snapshot

## Test plan

- [x] Build succeeds
- [x] Chain sync starts from Mithril slot after bootstrap