### PR TITLE
fix: --mithril-bootstrap-only implies --mithril-bootstrap

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -332,7 +332,8 @@ setupDB TraceWith{trace, contra} startingPoint mithrilOpts runner@RunCSMTTransac
     if new
         then do
             -- Check if Mithril bootstrap is enabled
-            if mithrilEnabled mithrilOpts
+            -- --mithril-bootstrap-only implies --mithril-bootstrap
+            if mithrilEnabled mithrilOpts || Mithril.mithrilBootstrapOnly mithrilOpts
                 then bootstrapFromMithril
                 else regularSetup
         else do


### PR DESCRIPTION
## Summary

- `--mithril-bootstrap-only` now automatically enables Mithril bootstrap
- No need to specify both `--mithril-bootstrap` and `--mithril-bootstrap-only`

Fixes #35

## Test plan

```bash
# Before: this did NOT bootstrap
cardano-utxo-chainsync --network preview --mithril-bootstrap-only -d /tmp/test

# After: this now bootstraps correctly
cardano-utxo-chainsync --network preview --mithril-bootstrap-only -d /tmp/test
```