### PR TITLE
fix: --mithril-bootstrap-only implies --mithril-bootstrap

### DIFF
--- a/lib/Cardano/UTxOCSMT/Mithril/Client.hs
+++ b/lib/Cardano/UTxOCSMT/Mithril/Client.hs
@@ -58,6 +58,7 @@ import Network.HTTP.Client
     , responseStatus
     )
 import Network.HTTP.Types.Status (statusCode)
+import System.Directory (createDirectoryIfMissing)
 import System.Exit (ExitCode (..))
 import System.Process.Typed
     ( proc
@@ -370,6 +371,8 @@ downloadSnapshotHttp
                                 (statusCode status)
                                 (T.pack "Download failed")
                     | otherwise -> do
+                        -- Ensure download directory exists
+                        createDirectoryIfMissing True mithrilDownloadDir
                         -- Write to temp file and extract
                         let archivePath = mithrilDownloadDir <> "/snapshot.tar.zst"
                         LBS.writeFile archivePath body


### PR DESCRIPTION
## Summary

- `--mithril-bootstrap-only` now implies `--mithril-bootstrap`, eliminating the need to specify both flags
- Added progress logging every 1000 slots during chain sync to provide visibility after Mithril bootstrap completes
- Fixed potential error when Mithril download directory doesn't exist

## Test plan

- [ ] Run with `--mithril-bootstrap-only` flag only and verify Mithril bootstrap runs
- [ ] Verify chain sync logs progress after bootstrap completes
- [ ] Test with fresh database directory

Fixes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)