### PR TITLE
Update generateInclusionProof API

### DIFF
--- a/.llm/issue-61-bump-haskell-csmt.md
+++ b/.llm/issue-61-bump-haskell-csmt.md
@@ -1,0 +1,50 @@
+# Issue 61: Update generateInclusionProof API
+
+## Summary
+
+Update haskell-csmt source-repository-package from `e33d7110ca9e708f367ca19c69020fc853be4980` to HEAD (`308d2232d9db8064698460e0aebc101dadbd6fe4`).
+
+## Progress
+
+- [x] Created issue #61
+- [x] Created worktree at `/code/cardano-utxo-csmt-issue-61`
+- [x] Updated cabal.project with new commit and SHA256 hash
+- [x] Fix breaking API changes
+- [x] Run tests (passed, except disk space issues on Mithril E2E tests)
+- [x] Create PR
+
+## API Changes
+
+### `generateInclusionProof` signature changed
+
+**Old:** `FromKV k v a -> Selector d Key (Indirect a) -> k -> Transaction m cf d ops (Maybe ByteString)`
+
+**New:** `FromKV k v Hash -> Selector d k v -> Selector d Key (Indirect Hash) -> k -> Transaction m cf d ops (Maybe (v, ByteString))`
+
+Changes:
+- Now takes an additional `Selector d k v` argument for the KV column
+- Returns `Maybe (v, ByteString)` instead of `Maybe ByteString` (value included with proof)
+
+**Affected files:**
+- `application/Cardano/UTxOCSMT/Application/Run/Main.hs`
+- `test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs`
+
+### `downloadSnapshotHttp` signature changed (incidental)
+
+Now requires a `Tracer IO MithrilTrace` as the first argument.
+
+**Affected files:**
+- `executables/memory-test/Main.hs`
+- `executables/extract-utxos/main.hs`
+
+## cabal.project Changes
+
+```diff
+source-repository-package
+  type: git
+  location: https://github.com/paolino/haskell-csmt
+-  tag: e33d7110ca9e708f367ca19c69020fc853be4980
+-  --sha256: sha256-krDEh3RM6ZJ5c4BMdbFd3/UX2TX5x/rafUmz/vpR/XA=
++  tag: 308d2232d9db8064698460e0aebc101dadbd6fe4
++  --sha256: sha256-yReAFtoHnGkXBQu3h7ESIDCgjT34bqWm5WeKDDTzhjc=
+```

--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -142,7 +142,7 @@ import Data.Tracer.TraceWith
     )
 import Data.Word (Word16, Word64)
 import Database.KV.Cursor (firstEntry)
-import Database.KV.Transaction (iterating, query)
+import Database.KV.Transaction (iterating)
 import Database.RocksDB
     ( BatchOp
     , ColumnFamily
@@ -640,12 +640,10 @@ queryInclusionProof
     -> IO (Maybe InclusionProofResponse)
 queryInclusionProof (RunCSMTTransaction runCSMT) txIdText txIx = do
     runCSMT $ do
-        proofBytes <- generateInclusionProof fromKVLazy CSMTCol txIn
-        txOut <- query KVCol txIn
+        result <- generateInclusionProof fromKVLazy KVCol CSMTCol txIn
         merkle <- queryMerkleRoot
         pure $ do
-            proof' <- proofBytes
-            out <- txOut
+            (out, proof') <- result
             let merkleText = fmap (Text.decodeUtf8 . convertToBase Base16 . renderHash) merkle
             pure
                 InclusionProofResponse

--- a/cabal.project
+++ b/cabal.project
@@ -20,8 +20,8 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/paolino/haskell-csmt
-  tag: e33d7110ca9e708f367ca19c69020fc853be4980
-  --sha256: sha256-krDEh3RM6ZJ5c4BMdbFd3/UX2TX5x/rafUmz/vpR/XA=
+  tag: 308d2232d9db8064698460e0aebc101dadbd6fe4
+  --sha256: sha256-yReAFtoHnGkXBQu3h7ESIDCgjT34bqWm5WeKDDTzhjc=
 
 source-repository-package
   type: git

--- a/executables/extract-utxos/main.hs
+++ b/executables/extract-utxos/main.hs
@@ -103,7 +103,7 @@ main = do
                 putStrLn "Found snapshot, downloading..."
 
                 -- Download snapshot
-                downloadResult <- downloadSnapshotHttp config snapshot
+                downloadResult <- downloadSnapshotHttp nullTracer config snapshot
                 case downloadResult of
                     Left err -> fail $ "Failed to download: " ++ show err
                     Right dbPath -> do

--- a/executables/memory-test/Main.hs
+++ b/executables/memory-test/Main.hs
@@ -13,9 +13,11 @@ module Main (main) where
 
 import Cardano.UTxOCSMT.Mithril.Client
     ( MithrilNetwork (..)
+    , MithrilTrace
     , defaultMithrilConfig
     , downloadSnapshotHttp
     , fetchLatestSnapshot
+    , renderMithrilTrace
     )
 import Cardano.UTxOCSMT.Mithril.Extraction
     ( ExtractionTrace (..)
@@ -78,6 +80,9 @@ optionsParser =
 tracer :: Tracer IO ExtractionTrace
 tracer = contramap renderExtractionTrace stdoutTracer
 
+mithrilTracer :: Tracer IO MithrilTrace
+mithrilTracer = contramap renderMithrilTrace stdoutTracer
+
 main :: IO ()
 main = do
     Options{optNetwork, optTmpDir} <-
@@ -101,7 +106,7 @@ main = do
             hFlush stdout
 
             -- Download snapshot
-            downloadResult <- downloadSnapshotHttp config snapshot
+            downloadResult <- downloadSnapshotHttp mithrilTracer config snapshot
             case downloadResult of
                 Left err -> fail $ "Failed to download: " ++ show err
                 Right dbPath -> do


### PR DESCRIPTION
## Summary

Update haskell-csmt dependency to `308d2232d9db8064698460e0aebc101dadbd6fe4` and adapt to API changes.

## Changes

- `generateInclusionProof` now takes an additional KV selector argument and returns `(value, proof)` tuple
- `downloadSnapshotHttp` now requires a `Tracer` as first argument

Closes #61