### PR TITLE
fix: make Mithril extraction failures fatal

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Query.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Query.hs
@@ -175,7 +175,7 @@ mkReadyResponse threshold mMetrics =
                     , slotsBehind = behind
                     }
   where
-    -- | Safe subtraction that returns 0 instead of underflowing
+    -- \| Safe subtraction that returns 0 instead of underflowing
     safeSub :: Word64 -> Word64 -> Word64
     safeSub a b
         | a >= b = a - b

--- a/application/Cardano/UTxOCSMT/Application/Run/Setup.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Setup.hs
@@ -299,19 +299,17 @@ setupDB
                                     , setupMithrilSlot = Just importSlot
                                     }
                         ImportFailed err -> do
-                            -- Fall back to regular setup if Mithril fails
                             trace $ Mithril $ ImportError err
-                            txRunTransaction clearBootstrapInProgress
-                            regularSetup
+                            error
+                                $ "Mithril bootstrap failed: "
+                                    <> show err
+                                    <> "\nCannot continue with incomplete bootstrap."
                         ImportExtractionFailed err -> do
-                            -- Fall back to regular setup if extraction fails
                             trace $ Mithril $ ImportExtractionError err
-                            txRunTransaction clearBootstrapInProgress
-                            regularSetup
-                        ImportSkipped _reason -> do
-                            -- Fall back to regular setup
-                            txRunTransaction clearBootstrapInProgress
-                            regularSetup
+                            error
+                                $ "Mithril extraction failed: "
+                                    <> show err
+                                    <> "\nCannot continue with incomplete bootstrap."
 
 {- | Check if the rollbacks column family is empty.
 

--- a/lib/Cardano/UTxOCSMT/Mithril/Import.hs
+++ b/lib/Cardano/UTxOCSMT/Mithril/Import.hs
@@ -73,8 +73,6 @@ data ImportResult
       ImportFailed MithrilError
     | -- | Import failed during extraction
       ImportExtractionFailed ExtractionError
-    | -- | Import was skipped (e.g., no snapshots available)
-      ImportSkipped String
 
 -- | Trace events during import
 data ImportTrace


### PR DESCRIPTION
## Summary

- Make `ImportFailed` and `ImportExtractionFailed` terminate the process instead of silently falling back to an empty database
- Leave bootstrap-in-progress marker set on failure, triggering cleanup on next startup
- Remove unused `ImportSkipped` constructor (users can opt out of Mithril via CLI)

Closes #67