### PR TITLE
fix: persist skip slot for crash recovery during header sync

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Config.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Config.hs
@@ -7,6 +7,8 @@ module Cardano.UTxOCSMT.Application.Run.Config
     , slotHash
     , mFinality
     , distance
+    , encodePoint
+    , decodePoint
     )
 where
 
@@ -42,7 +44,15 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Update
     ( newFinality
     )
 import Cardano.UTxOCSMT.Ouroboros.Types (Point)
-import Control.Lens (Prism', lazy, prism', strict, view)
+import Control.Lens
+    ( Prism'
+    , lazy
+    , preview
+    , prism'
+    , review
+    , strict
+    , view
+    )
 import Data.ByteString (StrictByteString)
 import Data.ByteString.Lazy (LazyByteString)
 import Data.ByteString.Short (fromShort)
@@ -195,6 +205,14 @@ slotHash
 slotHash (Network.Point Origin) = error "slotHash: Origin has no hash"
 slotHash (Network.Point (At (Network.Block _ (OneEraHash h)))) =
     Hash $ fromShort h
+
+-- | Encode a Point to ByteString for config storage
+encodePoint :: Point -> StrictByteString
+encodePoint = review (slotP prisms)
+
+-- | Decode a ByteString to Point for config storage
+decodePoint :: StrictByteString -> Maybe Point
+decodePoint = preview (slotP prisms)
 
 {- | Compute the finality point based on slot distance.
 

--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -7,7 +7,8 @@ module Cardano.UTxOCSMT.Application.Run.Main
 where
 
 import Cardano.UTxOCSMT.Application.Database.Implementation.Query
-    ( putBaseCheckpoint
+    ( clearSkipSlot
+    , putBaseCheckpoint
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( RunCSMTTransaction (..)
@@ -35,6 +36,8 @@ import Cardano.UTxOCSMT.Application.Run.Application
 import Cardano.UTxOCSMT.Application.Run.Config
     ( armageddonParams
     , context
+    , decodePoint
+    , encodePoint
     , mFinality
     , prisms
     , slotHash
@@ -199,7 +202,9 @@ main = withUtf8 $ do
 
             -- Create checkpoint action and skip configuration
             let setCheckpoint point =
-                    txRunTransaction runner $ putBaseCheckpoint point
+                    txRunTransaction runner $ do
+                        putBaseCheckpoint decodePoint encodePoint point
+                        clearSkipSlot decodePoint encodePoint
                 mSkipTargetSlot = SlotNo <$> setupMithrilSlot
 
             -- Log before starting the application

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -140,6 +140,7 @@ library library
   exposed-modules:
     Cardano.UTxOCSMT.Application.BlockFetch
     Cardano.UTxOCSMT.Application.ChainSync
+    Cardano.UTxOCSMT.Application.Database.Implementation.AppConfig
     Cardano.UTxOCSMT.Application.Database.Implementation.Armageddon
     Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     Cardano.UTxOCSMT.Application.Database.Implementation.Query

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/AppConfig.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/AppConfig.hs
@@ -1,0 +1,83 @@
+{- |
+Module      : Cardano.UTxOCSMT.Application.Database.Implementation.AppConfig
+Description : Application configuration stored in database
+Copyright   : (c) Paolo Veronelli, 2024
+License     : Apache-2.0
+
+This module defines the application configuration record that is
+persisted to the database using CBOR serialization.
+-}
+module Cardano.UTxOCSMT.Application.Database.Implementation.AppConfig
+    ( AppConfig (..)
+    , defaultAppConfig
+    , encodeAppConfig
+    , decodeAppConfig
+    )
+where
+
+import Codec.Serialise
+    ( deserialiseOrFail
+    , serialise
+    )
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Word (Word64)
+
+{- | Application configuration stored in the database
+
+This record holds all persistent configuration state:
+
+  * @configBaseCheckpoint@ - The base checkpoint for chain sync
+  * @configBootstrapInProgress@ - Whether bootstrap is incomplete
+  * @configSkipSlot@ - Target slot for skip mode after Mithril bootstrap
+-}
+data AppConfig slot = AppConfig
+    { configBaseCheckpoint :: Maybe slot
+    -- ^ Base checkpoint for chain sync (Nothing if not set)
+    , configBootstrapInProgress :: Bool
+    -- ^ True if bootstrap was started but not completed
+    , configSkipSlot :: Maybe Word64
+    -- ^ Target slot for skip mode (cleared when skip completes)
+    }
+    deriving stock (Show, Eq)
+
+-- | Default configuration with no checkpoint and no bootstrap in progress
+defaultAppConfig :: AppConfig slot
+defaultAppConfig =
+    AppConfig
+        { configBaseCheckpoint = Nothing
+        , configBootstrapInProgress = False
+        , configSkipSlot = Nothing
+        }
+
+-- | Serialize AppConfig to bytes using CBOR
+encodeAppConfig
+    :: (slot -> ByteString)
+    -- ^ Slot encoder
+    -> AppConfig slot
+    -> ByteString
+encodeAppConfig encodeSlot AppConfig{..} =
+    LBS.toStrict
+        $ serialise
+            ( fmap encodeSlot configBaseCheckpoint
+            , configBootstrapInProgress
+            , configSkipSlot
+            )
+
+-- | Deserialize AppConfig from bytes using CBOR
+decodeAppConfig
+    :: (ByteString -> Maybe slot)
+    -- ^ Slot decoder
+    -> ByteString
+    -> Maybe (AppConfig slot)
+decodeAppConfig decodeSlot bs = do
+    (mSlotBs, bootstrapInProgress, skipSlot) <-
+        either (const Nothing) Just
+            $ deserialiseOrFail (LBS.fromStrict bs)
+    mSlot <- traverse decodeSlot mSlotBs
+    pure
+        AppConfig
+            { configBaseCheckpoint = mSlot
+            , configBootstrapInProgress = bootstrapInProgress
+            , configSkipSlot = skipSlot
+            }


### PR DESCRIPTION
## Summary

- Persist the Mithril skip slot in the database so it survives restarts
- Refactored ConfigCol to use single CBOR-serialized AppConfig record
- Skip slot is restored on restart and cleared when skip phase completes

## Test plan

- [x] Unit tests for skip slot get/set/clear
- [x] Crash recovery test (database close/reopen preserves skip slot)
- [x] Smoke test (application starts correctly)

Fixes #76