### PR TITLE
feat: emit non-ready status during rollback operations

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Application.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Application.hs
@@ -18,6 +18,7 @@ import Cardano.UTxOCSMT.Application.ChainSync
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
     , State (..)
+    , TipOf
     , Update (..)
     )
 import Cardano.UTxOCSMT.Application.Metrics
@@ -55,11 +56,15 @@ import Ouroboros.Network.Point
     )
 import System.IO (BufferMode (..), hSetBuffering, stdout)
 
+-- | The tip type for Point is SlotNo
+type instance TipOf Point = SlotNo
+
 -- | Events emitted by the application
 data ApplicationTrace
     = ApplicationIntersectionAt Point
     | ApplicationIntersectionFailed
-    | ApplicationRollingBack Point
+    | -- | Rollback starting to the given point
+      ApplicationRollingBack Point
     | -- | Block processed at slot with UTxO change count
       ApplicationBlockProcessed SlotNo Int
     | -- | Header sync progress during Mithril catch-up
@@ -141,7 +146,7 @@ follower
     newFinalityTarget
     db = ($ db) $ fix $ \go currentDB ->
         Follower
-            { rollForward = \Fetched{fetchedPoint, fetchedBlock} -> do
+            { rollForward = \Fetched{fetchedPoint, fetchedBlock} tipSlot -> do
                 let ops = changeToOperation <$> uTxOs fetchedBlock
                     opsCount = length ops
                 replicateM_ opsCount trUTxO
@@ -154,7 +159,8 @@ follower
                     _ -> pure ()
                 newDB <- case currentDB of
                     Syncing update -> do
-                        newUpdate <- forwardTipApply update fetchedPoint ops
+                        newUpdate <-
+                            forwardTipApply update fetchedPoint tipSlot ops
                         finality <- newFinalityTarget
                         Syncing <$> case finality of
                             Nothing -> pure newUpdate

--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -87,7 +87,8 @@ import Data.Tracer.TraceWith
 import Main.Utf8 (withUtf8)
 import OptEnvConf (runParser)
 import Ouroboros.Consensus.Ledger.SupportsPeerSelection (PortNumber)
-import Ouroboros.Network.Block (SlotNo (..))
+import Ouroboros.Network.Block (SlotNo (..), pointSlot)
+import Ouroboros.Network.Point (WithOrigin (..))
 import Paths_cardano_utxo_csmt (version)
 import System.Exit (exitSuccess)
 import System.IO (BufferMode (..), hSetBuffering, stdout)
@@ -188,10 +189,17 @@ main = withUtf8 $ do
                     runner
 
             -- Now create the Update state (logs "New update state")
+            let onForward blockPoint chainTipSlot =
+                    case pointSlot blockPoint of
+                        At blockSlot
+                            | blockSlot >= chainTipSlot ->
+                                traceWith metricsEvent $ BootstrapPhaseEvent Synced
+                        _ -> pure ()
             (state, slots) <-
                 createUpdateState
                     (contra Update)
                     slotHash
+                    onForward
                     armageddonParams
                     runner
 

--- a/application/Cardano/UTxOCSMT/Application/Run/Traces.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Traces.hs
@@ -32,7 +32,7 @@ import Cardano.UTxOCSMT.Application.Metrics
     , MetricsEvent (..)
     )
 import Cardano.UTxOCSMT.Application.Run.Application
-    ( ApplicationTrace
+    ( ApplicationTrace (..)
     , renderApplicationTrace
     )
 import Cardano.UTxOCSMT.Mithril.Client
@@ -175,6 +175,8 @@ stealMetricsEvent (Update (UpdateForwardTip _ _ _ (Just merkleRoot))) =
     Just $ MerkleRootEvent merkleRoot
 stealMetricsEvent (NotEmpty point) =
     Just $ BaseCheckpointEvent point
+stealMetricsEvent (Application (ApplicationRollingBack _)) =
+    Just $ BootstrapPhaseEvent RollingBack
 stealMetricsEvent (Mithril ImportStarting) =
     Just $ BootstrapPhaseEvent Downloading
 stealMetricsEvent (Mithril (ImportMithril (MithrilDownloadProgress bytes))) =

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -1,12 +1,13 @@
 {
     "definitions": {
         "BootstrapPhase": {
-            "description": "Current bootstrap phase: extracting, syncing_headers, or synced",
+            "description": "Current bootstrap phase: downloading, counting, extracting, syncing_headers, rolling_back, or synced",
             "enum": [
                 "downloading",
                 "counting",
                 "extracting",
                 "syncing_headers",
+                "rolling_back",
                 "synced"
             ],
             "type": "string"

--- a/lib/Cardano/UTxOCSMT/Application/Database/Interface.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Interface.hs
@@ -23,6 +23,7 @@ module Cardano.UTxOCSMT.Application.Database.Interface
       -- * Update interface
     , Update (..)
     , State (..)
+    , TipOf
 
       -- * Database dump, for inspection/testing
     , Dump (..)
@@ -53,6 +54,9 @@ data State m slot key value
     | -- | Database is truncating, no possible rollbacks, the protocol should reset to Origin
       Truncating (Update m slot key value)
 
+-- | Type family mapping a slot type to its chain tip type
+type family TipOf slot
+
 {- | Represents an update to the database. We offer a continuation-based API so that
 the database implementation can thread an internal state without messing up with the
 monad stack.
@@ -61,9 +65,12 @@ Valid consumers should always pick the continuation
 data Update m slot key value = Update
     { forwardTipApply
         :: slot
+        -> TipOf slot
         -> [Operation key value]
         -> m (Update m slot key value)
-    -- ^ Apply operations at the given slot, moving the tip forward
+    {- ^ Apply operations at the given slot with current chain tip,
+    moving the tip forward
+    -}
     , rollbackTipApply
         :: WithOrigin slot
         -> m (State m slot key value)

--- a/lib/Cardano/UTxOCSMT/Application/Database/Properties.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Properties.hs
@@ -20,6 +20,7 @@ where
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Dump (..)
     , Operation (..)
+    , TipOf
     , emptyDump
     )
 import Cardano.UTxOCSMT.Application.Database.Properties.Expected
@@ -148,7 +149,10 @@ generateOperations = do
   with properties.
 -}
 populateWithSomeContent
-    :: (PropertyConstraints m slot key value, HasCallStack)
+    :: ( PropertyConstraints m slot key value
+       , HasCallStack
+       , TipOf slot ~ slot
+       )
     => PropertyWithExpected
         m
         slot
@@ -182,7 +186,7 @@ populateWithSomeContent = do
 forwarding must move the tip ahead
 -}
 propertyForwardBeforeTipIsNoOp
-    :: PropertyConstraints m slot key value
+    :: (PropertyConstraints m slot key value, TipOf slot ~ slot)
     => PropertyWithExpected m slot key value ()
 propertyForwardBeforeTipIsNoOp = do
     Generator{genSlot} <- asksGenerator
@@ -210,7 +214,7 @@ associations are updated by applying the changes
 old associations that were not deleted remain
 -}
 propertyForwardAfterTipAppliesChanges
-    :: PropertyConstraints m slot key value
+    :: (PropertyConstraints m slot key value, TipOf slot ~ slot)
     => PropertyWithExpected m slot key value ()
 propertyForwardAfterTipAppliesChanges = do
     Generator{genSlot} <- asksGenerator

--- a/lib/Cardano/UTxOCSMT/Application/Metrics/Types.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Metrics/Types.hs
@@ -85,6 +85,8 @@ data BootstrapPhase
       Extracting
     | -- | Syncing headers after Mithril import
       SyncingHeaders
+    | -- | Rolling back due to chain reorganization
+      RollingBack
     | -- | Fully synced with chain tip
       Synced
     deriving (Show, Eq)
@@ -95,6 +97,7 @@ instance ToJSON BootstrapPhase where
         Counting -> "counting"
         Extracting -> "extracting"
         SyncingHeaders -> "syncing_headers"
+        RollingBack -> "rolling_back"
         Synced -> "synced"
 
 instance ToSchema BootstrapPhase where
@@ -108,11 +111,12 @@ instance ToSchema BootstrapPhase where
                    , "counting"
                    , "extracting"
                    , "syncing_headers"
+                   , "rolling_back"
                    , "synced"
                    ]
             & description
-                ?~ "Current bootstrap phase: extracting, syncing_headers, \
-                   \or synced"
+                ?~ "Current bootstrap phase: downloading, counting, \
+                   \extracting, syncing_headers, rolling_back, or synced"
 
 -- | The signal we receive to update the metrics
 data MetricsEvent

--- a/lib/Cardano/UTxOCSMT/Ouroboros/Types.hs
+++ b/lib/Cardano/UTxOCSMT/Ouroboros/Types.hs
@@ -76,7 +76,8 @@ data ProgressOrRewind h
 
 -- | An event representing a roll forward or roll backward in the chain
 data Follower h = Follower
-    { rollForward :: h -> IO (Follower h)
+    { rollForward :: h -> Network.SlotNo -> IO (Follower h)
+    -- ^ Roll forward with header/block and current chain tip slot
     , rollBackward :: Point -> IO (ProgressOrRewind h)
     }
 

--- a/test/Cardano/UTxOCSMT/Application/Database/RocksDBSpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Database/RocksDBSpec.hs
@@ -36,6 +36,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
     ( mkUpdate
     )
+import Cardano.UTxOCSMT.Application.Database.Interface (TipOf)
 import Cardano.UTxOCSMT.Application.Database.Properties
     ( findValue
     , logOnFailure
@@ -85,6 +86,9 @@ import Test.QuickCheck
     , suchThat
     )
 import Test.QuickCheck.Monadic (monadic')
+
+-- | For testing, TipOf Int = Int (slot equals tip type)
+type instance TipOf Int = Int
 
 newtype GenSlot = GenSlot Int
     deriving (Show, Eq, Ord)
@@ -187,7 +191,12 @@ runRocksDBProperties prop =
     txRunner db = newRunRocksDBCSMTTransaction db prisms csmtContext
     armageddonParams = ArmageddonParams 1000 (mkHash "")
     query db = mkTransactionedQuery <$> newRunRocksDBTransaction db prisms
-    update = mkUpdate nullTracer (const $ mkHash "") armageddonParams
+    update =
+        mkUpdate
+            nullTracer
+            (const $ mkHash "")
+            (\_ _ -> pure ())
+            armageddonParams
 
 test
     :: PropertyWithExpected


### PR DESCRIPTION
## Summary

- Add `RollingBack` phase to `BootstrapPhase` so `/ready` returns `false` during rollbacks
- Add `TipOf` type family to map slot types to their chain tip types
- Pass chain tip slot through protocol to Update FSM
- Emit `Synced` when block slot >= chain tip after forward

## Test plan

- [x] `just build` passes
- [x] `just unit` passes (91 tests)
- [x] `just hlint` passes
- [x] `just format` passes
- [x] swagger.json updated with `rolling_back` enum value

Closes #73