### PR TITLE
fix: set bootstrap marker after download, not before

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Setup.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Setup.hs
@@ -282,14 +282,17 @@ setupDB
                                 , MithrilClient.mithrilAncillaryVk = ancillaryVk
                                 }
 
-                    -- Set bootstrap-in-progress marker before streaming
-                    txRunTransaction
-                        $ setBootstrapInProgress decodePoint encodePoint
+                    let markBootstrapInProgress =
+                            txRunTransaction
+                                $ setBootstrapInProgress
+                                    decodePoint
+                                    encodePoint
 
                     result <-
                         importFromMithril
                             (contramap Mithril tracer)
                             mithrilConfig
+                            markBootstrapInProgress
                             runner
 
                     case result of


### PR DESCRIPTION
## Summary

- Moves `setBootstrapInProgress` from before `importFromMithril` to after HTTP download succeeds but before streaming UTxOs into the DB
- Adds `IO ()` callback parameter to `importFromMithril` for the caller to set the marker at the right time
- Download failures no longer leave a stale marker that triggers unnecessary DB wipes on restart

Closes #94