### PR TITLE
fix: add visibility: public to all sub-libraries

### DIFF
--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -53,6 +53,17 @@ common warnings
     TypeOperators
     ViewPatterns
 
+library
+  -- Thin main library required for haskell.nix compatibility.
+  -- haskell.nix's redirect.nix expects a main library component;
+  -- without it, packages with only named sub-libraries cause
+  -- a TargetNotLocal evaluation error.
+  import:           warnings
+  default-language: Haskell2010
+  build-depends:
+    , base
+    , cardano-utxo-csmt:library
+
 library http
   import:           warnings
   visibility:       public


### PR DESCRIPTION
## Summary
- Add `visibility: public` to `http`, `application`, and `library` sub-libraries
- Required for external packages to depend on these sub-libraries via `cardano-utxo-csmt:library` etc.

## Test plan
- [ ] `cabal build` succeeds
- [ ] Downstream consumer (`cardano-mpfs-offchain`) can resolve `cardano-utxo-csmt:library`