### PR TITLE
fix: adapt to rocksdb-kv-transactions snapshot API

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -19,14 +19,18 @@ repository cardano-haskell-packages
 
 source-repository-package
   type: git
+  location: https://github.com/paolino/rocksdb-haskell.git
+  tag: a3e86b39f9510fea54abf734ee84aec33d0d683f
+
+source-repository-package
+  type: git
   location: https://github.com/paolino/haskell-csmt
-  tag: 7da179e86f64cacabf5bee730d84e9153bc37a48
+  tag: ea0a2bcd835723f054647060dafb837c67cba557
 
 source-repository-package
   type: git
   location: https://github.com/paolino/rocksdb-kv-transactions
-  tag: 2e151146f8bddcbc2ae694e451692e5c51b337ac
-  --sha256: sha256-hhgKUAApaBw2YBBLGqjgj8ZP1tbfAWuqRi1AJcez2jE=
+  tag: 0888387a5de81711273ea9b1e9d160decc33c231
 
 source-repository-package
   type: git

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -249,6 +249,7 @@ library library
     , time
     , typed-process
     , typed-protocols
+    , unliftio
 
   hs-source-dirs:   lib
   default-language: Haskell2010

--- a/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
@@ -51,6 +51,7 @@ import Database.KV.Database (mkColumns)
 import Database.KV.RocksDB (mkRocksDBDatabase)
 import Database.KV.Transaction qualified as L
 import Database.RocksDB (BatchOp, ColumnFamily, DB (..))
+import UnliftIO (MonadUnliftIO)
 
 type RocksDBTransaction m slot hash key value =
     L.Transaction m ColumnFamily (Columns slot hash key value) BatchOp
@@ -60,7 +61,7 @@ type RocksDBQuery m slot hash key value =
 
 -- | Create a 'RunTransaction' for RocksDB
 newRunRocksDBTransaction
-    :: (MonadIO m, MonadFail m, MonadMask m)
+    :: (MonadUnliftIO m, MonadFail m, MonadMask m)
     => DB
     -> Prisms slot hash key value
     -- ^ Prisms for serializing/deserializing keys and values
@@ -70,7 +71,7 @@ newRunRocksDBTransaction db prisms = do
     pure $ RunTransaction rt
 
 newRunRocksDBCSMTTransaction
-    :: (MonadIO m, MonadFail m, MonadMask m)
+    :: (MonadUnliftIO m, MonadFail m, MonadMask m)
     => DB
     -> Prisms slot hash key value
     -- ^ Prisms for serializing/deserializing keys and values
@@ -92,7 +93,7 @@ newRunRocksDBCSMTTransaction db prisms csmtContext = do
         $ \tx -> runReaderT (rt tx) csmtContext
 
 newRunTransaction
-    :: (MonadIO m, MonadIO n, MonadMask n, MonadFail n)
+    :: (MonadIO m, MonadUnliftIO n, MonadMask n, MonadFail n)
     => DB
     -> Prisms slot hash key value
     -> m
@@ -109,7 +110,7 @@ newRunTransaction db prisms =
         $ codecs prisms
 
 newRocksDBState
-    :: (MonadIO m, MonadFail m, Ord key, Ord slot, MonadMask m)
+    :: (MonadUnliftIO m, MonadFail m, Ord key, Ord slot, MonadMask m)
     => Tracer m (UpdateTrace slot hash)
     -> DB
     -> Prisms slot hash key value


### PR DESCRIPTION
## Summary

- Update `MonadIO` to `MonadUnliftIO` for functions using `mkRocksDBDatabase`
- Pin `rocksdb-haskell` fork, updated `haskell-csmt` and `rocksdb-kv-transactions`
- Add `unliftio` dependency