### PR TITLE
fix: auto-initialize fresh DB on first use

### DIFF
--- a/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
@@ -21,9 +21,10 @@ where
 
 import Cardano.UTxOCSMT.Application.Database.Implementation.Armageddon
     ( ArmageddonParams
+    , setup
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
-    ( Columns
+    ( Columns (..)
     , Prisms
     , codecs
     )
@@ -41,14 +42,18 @@ import Cardano.UTxOCSMT.Application.Database.Interface
     , TipOf
     , Update
     )
+import Control.Monad (when)
 import Control.Monad.Catch (MonadMask)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader
     ( ReaderT (..)
     )
-import Control.Tracer (Tracer)
+import Control.Tracer (Tracer, nullTracer)
+import Data.Maybe (isNothing)
+import Database.KV.Cursor (firstEntry)
 import Database.KV.Database (mkColumns)
 import Database.KV.RocksDB (mkRocksDBDatabase)
+import Database.KV.Transaction (iterating)
 import Database.KV.Transaction qualified as L
 import Database.RocksDB (BatchOp, ColumnFamily, DB (..))
 import UnliftIO (MonadUnliftIO)
@@ -132,6 +137,7 @@ newRocksDBState
     onForward
     armageddonParams = do
         runner <- newRunRocksDBCSMTTransaction db prisms csmtContext
+        ensureInitialized runner armageddonParams
         (,runner)
             <$> newState tracer slotHash onForward armageddonParams runner
 
@@ -145,4 +151,20 @@ createUpdateState
     -> ArmageddonParams hash
     -> RunCSMTTransaction ColumnFamily BatchOp slot hash key value m
     -> m (Update m slot key value, [slot])
-createUpdateState = newState
+createUpdateState tracer slotHash onForward armageddonParams runner = do
+    ensureInitialized runner armageddonParams
+    newState tracer slotHash onForward armageddonParams runner
+
+{- | Ensure the database has been initialized with an Origin rollback point.
+This makes the public API self-initializing so callers can't forget to
+call 'setup' before creating state.
+-}
+ensureInitialized
+    :: (Ord slot, Monad m)
+    => RunCSMTTransaction cf op slot hash key value m
+    -> ArmageddonParams hash
+    -> m ()
+ensureInitialized runner@RunCSMTTransaction{txRunTransaction} armageddonParams = do
+    empty <-
+        txRunTransaction $ iterating RollbackPoints $ isNothing <$> firstEntry
+    when empty $ setup nullTracer runner armageddonParams


### PR DESCRIPTION
Closes #101

## Summary

- `newRocksDBState` and `createUpdateState` now call `ensureInitialized` before `newState`
- `ensureInitialized` checks if `RollbackPoints` is empty and calls `setup` (inserts `Origin`) when needed
- Idempotent: no-op when `setup` was already called (e.g. via `setupDB`)

## Test plan

- [x] All 99 existing tests pass
- [x] Fourmolu clean
- [x] Full CI green (`just CI`)