### PR TITLE
feat: replace Yaci with cardano-node devnet in E2E

### DIFF
--- a/e2e/docker-compose.n2n.yml
+++ b/e2e/docker-compose.n2n.yml
@@ -1,29 +1,23 @@
 services:
-  yaci-cli:
-    image: bloxbean/yaci-cli:0.11.0-beta1
-    ports:
-      - "10000:10000"
-      - "3001:3001"
+  cardano-node:
+    image: ghcr.io/paolino/cardano-node-clients/devnet:10.5.4
     volumes:
-      - ./node.properties:/app/config/node.properties
-      - node-ipc:/clusters
-    entrypoint: ["/app/yaci-cli"]
-    command: ["create-node", "-o", "--start"]
+      - node-data:/data
     healthcheck:
-      test: ["CMD", "test", "-S", "/clusters/nodes/default/node/node.sock"]
+      test: ["CMD", "test", "-S", "/data/node.sock"]
       interval: 5s
       timeout: 5s
       retries: 60
-      start_period: 30s
+      start_period: 10s
 
   cardano-utxo:
     image: cardano-utxo:e2e
     depends_on:
-      yaci-cli:
+      cardano-node:
         condition: service_healthy
     command:
       - "--node-name"
-      - "yaci-cli"
+      - "cardano-node"
       - "--node-port"
       - "3001"
       - "--network"
@@ -60,4 +54,4 @@ services:
         exit 1
 
 volumes:
-  node-ipc:
+  node-data:

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,30 +1,25 @@
 services:
-  yaci-cli:
-    image: bloxbean/yaci-cli:0.11.0-beta1
-    ports:
-      - "10000:10000"
+  cardano-node:
+    image: ghcr.io/paolino/cardano-node-clients/devnet:10.5.4
     volumes:
-      - ./node.properties:/app/config/node.properties
-      - node-ipc:/clusters
-    entrypoint: ["/app/yaci-cli"]
-    command: ["create-node", "-o", "--start"]
+      - node-data:/data
     healthcheck:
-      test: ["CMD", "test", "-S", "/clusters/nodes/default/node/node.sock"]
+      test: ["CMD", "test", "-S", "/data/node.sock"]
       interval: 5s
       timeout: 5s
       retries: 60
-      start_period: 30s
+      start_period: 10s
 
   cardano-utxo:
     image: cardano-utxo:e2e
     depends_on:
-      yaci-cli:
+      cardano-node:
         condition: service_healthy
     volumes:
-      - node-ipc:/clusters:ro
+      - node-data:/data:ro
     command:
       - "--socket-path"
-      - "/clusters/nodes/default/node/node.sock"
+      - "/data/node.sock"
       - "--network"
       - "devnet"
       - "--db-path"
@@ -59,4 +54,4 @@ services:
         exit 1
 
 volumes:
-  node-ipc:
+  node-data:

--- a/e2e/node.properties
+++ b/e2e/node.properties
@@ -1,2 +1,0 @@
-conwayHardForkAtEpoch=1
-shiftStartTimeBehind=true

--- a/justfile
+++ b/justfile
@@ -118,7 +118,7 @@ e2e-build:
     echo "Loaded: $loaded"
     docker image tag "$loaded" cardano-utxo:e2e
 
-# Run N2C E2E test against Yaci DevKit
+# Run N2C E2E test against cardano-node devnet
 e2e:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -129,7 +129,7 @@ e2e:
         --exit-code-from e2e-test
     docker compose -f e2e/docker-compose.yml down -v
 
-# Run N2N E2E test against Yaci DevKit
+# Run N2N E2E test against cardano-node devnet
 e2e-n2n:
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
Closes #108

## Summary

- Replace `bloxbean/yaci-cli` with `ghcr.io/paolino/cardano-node-clients/devnet:10.5.4` in both N2C and N2N E2E tests
- Delete `e2e/node.properties` (Yaci-specific config)
- Devnet image is built from cardano-node-clients PR [#9](https://github.com/paolino/cardano-node-clients/pull/9)

## Test plan

- [ ] Merge cardano-node-clients PR #9 first (publishes the devnet image)
- [ ] E2E N2C test passes in CI
- [ ] E2E N2N test passes in CI