### PR TITLE
feat: Byron genesis bootstrap for from-genesis sync

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -191,6 +191,7 @@ main = withUtf8 $ do
                     tracer
                     startingPoint
                     (genesisFile options)
+                    (byronGenesisFile options)
                     mithrilOptions
                     (networkMagic options)
                     setupNodeName

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -437,6 +437,7 @@ test-suite e2e-tests
     , temporary
     , time
     , unix
+
 benchmark bench
   import:           warnings
   default-language: Haskell2010

--- a/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
+++ b/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
@@ -110,6 +110,7 @@ spec = describe "Genesis chain sync" $ do
                                             nullTracer
                                             originPoint
                                             (Just shelleyGenesisPath)
+                                            Nothing
                                             disabledMithril
                                             devnetMagic
                                             "localhost"

--- a/lib/Cardano/UTxOCSMT/Application/Options.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Options.hs
@@ -136,6 +136,8 @@ data Options = Options
     -- ^ Skip node connection validation before Mithril bootstrap
     , genesisFile :: Maybe FilePath
     -- ^ Path to shelley-genesis.json for bootstrap from genesis
+    , byronGenesisFile :: Maybe FilePath
+    -- ^ Path to byron-genesis.json for bootstrap from genesis
     }
 
 -- | Get effective network magic from options
@@ -362,6 +364,21 @@ genesisFileOption =
             , option
             ]
 
+byronGenesisFileOption :: Parser (Maybe FilePath)
+byronGenesisFileOption =
+    optional
+        $ setting
+            [ long "byron-genesis-file"
+            , conf "byron-genesis-file"
+            , help
+                "Path to byron-genesis.json for bootstrapping \
+                \from genesis. Inserts nonAvvmBalances into \
+                \the CSMT before chain sync starts from Origin."
+            , metavar "FILE"
+            , reader str
+            , option
+            ]
+
 -- | Main options parser with YAML config file support
 optionsParser :: Parser Options
 optionsParser = withYamlConfig configFileOption optionsParserCore
@@ -383,6 +400,7 @@ optionsParserCore =
         <*> syncThresholdOption
         <*> skipNodeValidationSwitch
         <*> genesisFileOption
+        <*> byronGenesisFileOption
   where
     mkOptions
         net
@@ -397,7 +415,8 @@ optionsParserCore =
         mithril
         threshold
         skipValidation
-        genesis =
+        genesis
+        byronGenesis =
             Options
                 { network = net
                 , connectionMode = connMode
@@ -416,4 +435,5 @@ optionsParserCore =
                 , syncThreshold = threshold
                 , skipNodeValidation = skipValidation
                 , genesisFile = genesis
+                , byronGenesisFile = byronGenesis
                 }

--- a/lib/Cardano/UTxOCSMT/Bootstrap/Genesis.hs
+++ b/lib/Cardano/UTxOCSMT/Bootstrap/Genesis.hs
@@ -2,32 +2,55 @@
 Module      : Cardano.UTxOCSMT.Bootstrap.Genesis
 Description : Genesis UTxO bootstrap for from-genesis sync
 
-Parse a @shelley-genesis.json@ file and extract the @initialFunds@
-as CBOR-encoded (TxIn, TxOut) pairs ready for CSMT insertion.
-This allows syncing from genesis without Mithril by pre-populating
-the tree with genesis UTxOs before chain sync starts.
+Parse genesis files and extract UTxO pairs ready for CSMT insertion.
+Supports both Shelley genesis (@initialFunds@) and Byron genesis
+(@nonAvvmBalances@). This allows syncing from genesis without Mithril
+by pre-populating the tree with genesis UTxOs before chain sync starts.
 -}
 module Cardano.UTxOCSMT.Bootstrap.Genesis
     ( readShelleyGenesis
     , genesisUtxoPairs
+    , readByronGenesisUtxoPairs
     )
 where
 
-import Cardano.Ledger.Address (Addr)
+import Cardano.Chain.Common (unsafeGetLovelace)
+import Cardano.Chain.Genesis
+    ( GenesisData (..)
+    , GenesisDataError
+    , GenesisNonAvvmBalances (..)
+    )
+import Cardano.Chain.Genesis qualified as Byron
+import Cardano.Chain.UTxO qualified as Byron
+import Cardano.Crypto.Hashing (serializeCborHash)
+import Cardano.Ledger.Address
+    ( Addr (..)
+    , BootstrapAddress (..)
+    )
+import Cardano.Ledger.Api.Tx.In (mkTxIxPartial)
+import Cardano.Ledger.Api.Tx.In qualified as Shelley
 import Cardano.Ledger.Api.Tx.Out (mkBasicTxOut)
 import Cardano.Ledger.Binary (natVersion, serialize)
-import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Shelley.Genesis
     ( ShelleyGenesis (..)
     , initialFundsPseudoTxIn
     )
 import Cardano.Ledger.Val (inject)
+import Cardano.UTxOCSMT.Application.UTxOs
+    ( byronTxIdToShelley
+    , cborEncode
+    )
+import Control.Exception (Exception, throwIO)
+import Control.Monad.Except (runExceptT)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KM
 import Data.ByteString.Lazy (ByteString)
 import Data.ByteString.Lazy qualified as BSL
+import Data.Coerce (coerce)
 import Data.ListMap (unListMap)
+import Data.Map.Strict qualified as Map
 
 {- | Read and parse a Shelley genesis JSON file.
 Patches @systemStart@ if set to @\"PLACEHOLDER\"@.
@@ -60,6 +83,60 @@ genesisUtxoPairs genesis =
             txOut =
                 mkBasicTxOut @ConwayEra addr (inject coin)
         in  (serialize ver txIn, serialize ver txOut)
+
+newtype GenesisDataException
+    = GenesisDataException GenesisDataError
+    deriving (Show)
+
+instance Exception GenesisDataException
+
+{- | Read a Byron genesis file and extract UTxO pairs as
+CBOR-encoded (TxIn, TxOut) using the same encoding as chain
+sync. Byron genesis UTxOs use
+@TxInUtxo (serializeCborHash address) 0@ as TxIn, converted
+to Shelley format for consistent CSMT keys.
+Zero-balance entries are filtered out.
+-}
+readByronGenesisUtxoPairs
+    :: FilePath -> IO [(ByteString, ByteString)]
+readByronGenesisUtxoPairs fp = do
+    r <- runExceptT . Byron.readGenesisData $ fp
+    case r of
+        Left err -> throwIO $ GenesisDataException err
+        Right (gd, _) ->
+            pure
+                $ byronUtxoPairs
+                $ gdNonAvvmBalances gd
+
+byronUtxoPairs
+    :: GenesisNonAvvmBalances
+    -> [(ByteString, ByteString)]
+byronUtxoPairs (GenesisNonAvvmBalances m) =
+    mkPair <$> filter nonZero (Map.toList m)
+  where
+    nonZero (_, lovelace) = unsafeGetLovelace lovelace > 0
+    mkPair (addr, lovelace) =
+        let
+            -- Byron genesis convention: TxId = hash(CBOR(address))
+            byronTxId :: Byron.TxId
+            byronTxId = coerce (serializeCborHash addr)
+            -- Convert to Shelley TxIn format
+            shelleyTxIn :: Shelley.TxIn
+            shelleyTxIn =
+                Shelley.TxIn
+                    (byronTxIdToShelley byronTxId)
+                    (mkTxIxPartial (0 :: Integer))
+            -- Convert Byron TxOut to Conway-era
+            txOut =
+                mkBasicTxOut @ConwayEra
+                    (AddrBootstrap (BootstrapAddress addr))
+                    ( inject
+                        $ Coin
+                        $ toInteger
+                        $ unsafeGetLovelace lovelace
+                    )
+        in
+            (cborEncode shelleyTxIn, cborEncode txOut)
 
 {- | Replace @\"PLACEHOLDER\"@ systemStart with a dummy UTC time
 so that 'FromJSON' succeeds.


### PR DESCRIPTION
## Summary
- Add `--byron-genesis-file` option for pre-populating the CSMT with Byron genesis UTxOs (`nonAvvmBalances`)
- Required for syncing from genesis on preprod/mainnet where initial funds are in Byron genesis, not Shelley
- Byron TxIns computed using `serializeCborHash(address)` convention, converted to Shelley format

Closes #58