### PR TITLE
fix: parameterize EpochSlots for Byron codec

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Application.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Application.hs
@@ -7,6 +7,7 @@ module Cardano.UTxOCSMT.Application.Run.Application
 where
 
 import CSMT ()
+import Cardano.Chain.Slotting (EpochSlots)
 import Cardano.UTxOCSMT.Application.BlockFetch
     ( EventQueueLength
     , Fetched (..)
@@ -210,7 +211,9 @@ rollingBack TraceWith{trace, tracer} trUTxO newFinalityTarget point follower' st
         _ -> error "rollingBack: cannot roll back while intersecting"
 
 application
-    :: NetworkMagic
+    :: EpochSlots
+    -- ^ Epoch slots for Byron codec
+    -> NetworkMagic
     -- ^ Network magic
     -> String
     -- ^ Node name
@@ -236,6 +239,7 @@ application
     -- ^ Finality target. TODO redesign the Update object to avoid this
     -> IO Void
 application
+    epochSlots
     networkMagic
     nodeName
     portNumber
@@ -289,6 +293,7 @@ application
                             else availablePoints
             result <-
                 runNodeApplication
+                    epochSlots
                     networkMagic
                     nodeName
                     portNumber
@@ -303,7 +308,9 @@ application
 
 -- | N2C variant: connects via Unix socket, no BlockFetch needed
 applicationN2C
-    :: NetworkMagic
+    :: EpochSlots
+    -- ^ Epoch slots for Byron codec
+    -> NetworkMagic
     -- ^ Network magic
     -> FilePath
     -- ^ Socket path
@@ -325,6 +332,7 @@ applicationN2C
     -- ^ Finality target
     -> IO Void
 applicationN2C
+    epochSlots
     networkMagic'
     socketPath
     startingPoint
@@ -376,6 +384,7 @@ applicationN2C
 
             result <-
                 runLocalNodeApplication
+                    epochSlots
                     networkMagic'
                     socketPath
                     chainSyncApp

--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -6,6 +6,7 @@ module Cardano.UTxOCSMT.Application.Run.Main
     )
 where
 
+import Cardano.Chain.Slotting (EpochSlots (..))
 import Cardano.UTxOCSMT.Application.Database.Implementation.Query
     ( clearSkipSlot
     , putBaseCheckpoint
@@ -27,6 +28,7 @@ import Cardano.UTxOCSMT.Application.Metrics
 import Cardano.UTxOCSMT.Application.Options
     ( ConnectionMode (..)
     , Options (..)
+    , epochSlotsFor
     , networkMagic
     , optionsParser
     )
@@ -241,10 +243,13 @@ main = withUtf8 $ do
                 Nothing ->
                     traceWith metricsEvent $ BootstrapPhaseEvent Synced
 
+            let epochSlots =
+                    EpochSlots $ epochSlotsFor $ network options
             result <-
                 ( case connectionMode options of
                     N2N{n2nHost, n2nPort} ->
                         application
+                            epochSlots
                             (networkMagic options)
                             n2nHost
                             n2nPort
@@ -259,6 +264,7 @@ main = withUtf8 $ do
                             (mFinality runner)
                     N2C{n2cSocket} ->
                         applicationN2C
+                            epochSlots
                             (networkMagic options)
                             n2cSocket
                             setupStartingPoint

--- a/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
+++ b/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
@@ -9,6 +9,7 @@ module Cardano.UTxOCSMT.E2E.GenesisChainSyncSpec
     ( spec
     ) where
 
+import Cardano.Chain.Slotting (EpochSlots (..))
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
     )
@@ -133,6 +134,7 @@ spec = describe "Genesis chain sync" $ do
                                         timeout
                                             15_000_000
                                             $ applicationN2C
+                                                (EpochSlots 4320)
                                                 devnetMagic
                                                 socketPath
                                                 setupStartingPoint

--- a/lib/Cardano/UTxOCSMT/Application/Options.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Options.hs
@@ -9,6 +9,7 @@ module Cardano.UTxOCSMT.Application.Options
 
       -- * Derived option accessors
     , networkMagic
+    , epochSlotsFor
 
       -- * Re-exports for Mithril
     , MithrilOptions (..)
@@ -98,6 +99,13 @@ networkMagicFor Mainnet = NetworkMagic 764824073
 networkMagicFor Preprod = NetworkMagic 1
 networkMagicFor Preview = NetworkMagic 2
 networkMagicFor Devnet = NetworkMagic 42
+
+-- | Get Byron epoch slots for a Cardano network
+epochSlotsFor :: CardanoNetwork -> Word64
+epochSlotsFor Mainnet = 21600
+epochSlotsFor Preprod = 21600
+epochSlotsFor Preview = 4320
+epochSlotsFor Devnet = 4320
 
 -- | Get Mithril network for a Cardano network
 mithrilNetworkFor :: CardanoNetwork -> MithrilNetwork

--- a/lib/Cardano/UTxOCSMT/Ouroboros/Application.hs
+++ b/lib/Cardano/UTxOCSMT/Ouroboros/Application.hs
@@ -4,6 +4,7 @@ module Cardano.UTxOCSMT.Ouroboros.Application
     )
 where
 
+import Cardano.Chain.Slotting (EpochSlots)
 import Cardano.UTxOCSMT.Application.BlockFetch
     ( BlockFetchApplication
     )
@@ -48,7 +49,9 @@ maximumMiniProtocolLimits =
         }
 
 mkOuroborosApplication
-    :: ChainSyncApplication
+    :: EpochSlots
+    -- ^ Byron epoch slots for codec configuration
+    -> ChainSyncApplication
     -- ^ chainSync
     -> BlockFetchApplication
     -- ^ blockFetch
@@ -61,7 +64,7 @@ mkOuroborosApplication
         IO
         ()
         Void
-mkOuroborosApplication chainSyncApp blockFetchApp keepAliveApp =
+mkOuroborosApplication epochSlots chainSyncApp blockFetchApp keepAliveApp =
     OuroborosApplication
         { getOuroborosApplication =
             [ MiniProtocol
@@ -89,14 +92,14 @@ mkOuroborosApplication chainSyncApp blockFetchApp keepAliveApp =
         $ mkMiniProtocolCbFromPeer
         $ \_ctx ->
             ( nullTracer
-            , codecChainSync
+            , codecChainSync epochSlots
             , ChainSync.chainSyncClientPeer chainSyncApp
             )
     runFetchBlocks = InitiatorProtocolOnly
         $ mkMiniProtocolCbFromPeer
         $ \_ctx ->
             ( nullTracer
-            , codecBlockFetch
+            , codecBlockFetch epochSlots
             , BlockFetch.blockFetchClientPeer blockFetchApp
             )
     runKeepAlive = InitiatorProtocolOnly

--- a/lib/Cardano/UTxOCSMT/Ouroboros/Connection.hs
+++ b/lib/Cardano/UTxOCSMT/Ouroboros/Connection.hs
@@ -15,6 +15,7 @@ module Cardano.UTxOCSMT.Ouroboros.Connection
     )
 where
 
+import Cardano.Chain.Slotting (EpochSlots)
 import Cardano.UTxOCSMT.Application.BlockFetch
     ( BlockFetchApplication
     )
@@ -75,7 +76,9 @@ import System.Timeout (timeout)
 
 -- | Connect to a node-to-node chain sync server and run the given application
 runNodeApplication
-    :: NetworkMagic
+    :: EpochSlots
+    -- ^ Byron epoch slots for codec configuration
+    -> NetworkMagic
     -- ^ The network magic
     -> String
     -- ^ host
@@ -87,6 +90,7 @@ runNodeApplication
     -- ^ application
     -> IO (Either SomeException (Either () Void))
 runNodeApplication
+    epochSlots
     magic
     peerName
     peerPort
@@ -121,6 +125,7 @@ runNodeApplication
                 )
                 ( const
                     $ mkOuroborosApplication
+                        epochSlots
                         chainSyncApplication
                         blockFetchApplication
                         keepAliveApplication


### PR DESCRIPTION
## Summary

- Thread `EpochSlots` from Options through the entire protocol stack instead of hardcoding `EpochSlots 42` in Codecs.hs
- Add `epochSlotsFor` to Options.hs (21600 for mainnet/preprod, 4320 for preview/devnet)
- Wrong value caused garbled Byron header decoding, invalid BlockFetch ranges, and "Connection reset by peer" on preprod N2N

Closes #115