### PR TITLE
fix: skip DB writes for empty blocks

### DIFF
--- a/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
@@ -88,7 +88,7 @@ newRunTransaction db prisms =
         $ codecs prisms
 
 newRocksDBState
-    :: (MonadUnliftIO m, MonadFail m, Ord key, Ord slot, MonadMask m)
+    :: (MonadUnliftIO m, MonadFail m, Ord key, Ord slot, Show slot, MonadMask m)
     => Tracer m (UpdateTrace slot hash)
     -> DB
     -> Prisms slot hash key value
@@ -118,7 +118,7 @@ newRocksDBState
 
 -- | Create Update state from an existing runner
 createUpdateState
-    :: (MonadFail m, Ord key, Ord slot)
+    :: (MonadFail m, Ord key, Ord slot, Show slot)
     => Tracer m (UpdateTrace slot hash)
     -> FromKV key value hash
     -> Hashing hash


### PR DESCRIPTION
## Summary

- Skip rollback point creation for blocks with no UTxO operations
- Empty blocks were causing unnecessary DB writes (queryTip + queryMerkleRoot + insert RollbackPoint) at 2-7ms each
- Adds `Show slot` constraint for improved error messages

Interim fix — unconditionally drops empty blocks. See #112 for the proper counter-based approach.

Related to #112