### PR TITLE
fix: handle failed Plutus transactions (isValid=False)

### DIFF
--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -201,6 +201,7 @@ library library
     , cardano-crypto-class
     , cardano-crypto-wrapper
     , cardano-data
+    , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-babbage
     , cardano-ledger-binary
@@ -246,6 +247,7 @@ library library
     , serialise
     , streaming
     , streaming-bytestring
+    , cardano-strict-containers
     , strict-sop-core
     , strict-stm
     , swagger2


### PR DESCRIPTION
Closes #113

Cherry-pick of the isValid fix that was lost when PR #118 merged into its stacked base branch instead of main.

Skips collateral inputs/outputs for failed Plutus transactions (isValid=False) per Alonzo/Babbage/Conway ledger specs.