### PR TITLE
refactor: swap csmt to mts and introduce CSMTOps adapter

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,6 +16,8 @@ jobs:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build executable
         run: nix build .#cardano-utxo --quiet
+      - name: Build e2e-tests
+        run: nix build .#e2e-tests --quiet
       - name: Build docker image
         run: nix build .#docker-image -o output-docker-image --quiet
       - name: Upload Artifact
@@ -73,7 +75,22 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Check Formatting
-        run: nix develop --quiet -c just format
+        run: |
+          nix develop --quiet -c just format
+          if ! git diff --exit-code --quiet; then
+            echo "Code formatting is out of date. Please run 'just format' and commit the changes."
+            exit 1
+          fi
+  hlint:
+    name: HLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Run HLint
+        run: nix develop --quiet -c just hlint
   e2e:
     name: N2C E2E test
     needs: build

--- a/application/Cardano/UTxOCSMT/Application/Run/Application.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Application.hs
@@ -29,7 +29,10 @@ import Cardano.UTxOCSMT.Application.Metrics
     ( BootstrapPhase (..)
     , MetricsEvent (..)
     )
-import Cardano.UTxOCSMT.Application.UTxOs (Change (..), uTxOsWithTxCount)
+import Cardano.UTxOCSMT.Application.UTxOs
+    ( Change (..)
+    , uTxOsWithTxCount
+    )
 import Cardano.UTxOCSMT.Ouroboros.Connection (runNodeApplication)
 import Cardano.UTxOCSMT.Ouroboros.ConnectionN2C
     ( runLocalNodeApplication

--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -14,6 +14,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Query
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
     , RunTransaction (..)
+    , mkCSMTOps
     )
 import Cardano.UTxOCSMT.Application.Database.RocksDB
     ( createUpdateState
@@ -157,6 +158,7 @@ main = withUtf8 $ do
         withRocksDB dbPath $ \db -> do
             -- Create runner first (no logging)
             let CSMTContext{fromKV = fkv, hashing = h} = context
+                ops = mkCSMTOps fkv h
             runner <-
                 newRunRocksDBTransaction
                     db
@@ -200,8 +202,7 @@ main = withUtf8 $ do
                     setupNodePort
                     setupSkipValidation
                     armageddonParams
-                    fkv
-                    h
+                    ops
                     runner
 
             -- Now create the Update state (logs "New update state")
@@ -214,8 +215,7 @@ main = withUtf8 $ do
             (state, slots) <-
                 createUpdateState
                     (contra Update)
-                    fkv
-                    h
+                    ops
                     slotHash
                     onForward
                     armageddonParams

--- a/application/Cardano/UTxOCSMT/Application/Run/Setup.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Setup.hs
@@ -17,7 +17,6 @@ where
 -- initialization of new databases, and optional bootstrapping from Mithril
 -- snapshots for faster initial sync.
 
-import CSMT (FromKV, Hashing)
 import Cardano.UTxOCSMT.Application.Database.Implementation.Armageddon
     ( ArmageddonParams
     , cleanup
@@ -36,8 +35,8 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Query
     , setSkipSlot
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
-    ( RunTransaction (..)
-    , insertCSMT
+    ( CSMTOps (..)
+    , RunTransaction (..)
     )
 import Cardano.UTxOCSMT.Application.Options (MithrilOptions (..))
 import Cardano.UTxOCSMT.Application.Run.Config
@@ -83,6 +82,7 @@ import Data.Tracer.TraceWith
 import Data.Word (Word16, Word64)
 import Database.KV.Cursor (firstEntry)
 import Database.KV.Transaction (iterating)
+import Database.KV.Transaction qualified as L
 import Database.RocksDB (BatchOp, ColumnFamily)
 import Network.HTTP.Client (newManager)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
@@ -135,10 +135,17 @@ setupDB
     -- ^ Skip node validation
     -> ArmageddonParams hash
     -- ^ Parameters for database initialization
-    -> FromKV LazyByteString LazyByteString hash
-    -- ^ Key/value codec for CSMT operations
-    -> Hashing hash
-    -- ^ Hashing operations for CSMT
+    -> CSMTOps
+        ( L.Transaction
+            IO
+            ColumnFamily
+            (Columns Point hash LazyByteString LazyByteString)
+            BatchOp
+        )
+        LazyByteString
+        LazyByteString
+        hash
+    -- ^ CSMT operations (insert, delete, root hash)
     -> RunTransaction
         ColumnFamily
         BatchOp
@@ -161,8 +168,7 @@ setupDB
     nodePort
     skipValidation
     armageddonParams
-    fkv
-    h
+    ops
     runner@RunTransaction{transact} = do
         -- Check for incomplete bootstrap and clean up if needed
         incomplete <- transact $ isBootstrapInProgress decodePoint
@@ -273,7 +279,7 @@ setupDB
                 Nothing -> pure []
             let pairs = byronPairs ++ shelleyPairs
             transact $ do
-                forM_ pairs $ \(k, v) -> insertCSMT fkv h k v
+                forM_ pairs $ uncurry (csmtInsert ops)
                 putBaseCheckpoint
                     decodePoint
                     encodePoint
@@ -343,14 +349,13 @@ setupDB
                                     decodePoint
                                     encodePoint
 
+                    let insertIO k v = transact $ csmtInsert ops k v
                     result <-
                         importFromMithril
                             (contramap Mithril tracer)
                             mithrilConfig
                             markBootstrapInProgress
-                            fkv
-                            h
-                            runner
+                            insertIO
 
                     case result of
                         ImportSuccess{importCheckpoint, importSlot} -> do

--- a/bench/Bench/CSMT.hs
+++ b/bench/Bench/CSMT.hs
@@ -28,8 +28,9 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
+    , CSMTOps (..)
     , RunTransaction (..)
-    , insertCSMT
+    , mkCSMTOps
     )
 import Cardano.UTxOCSMT.Application.Database.RocksDB
     ( newRunRocksDBTransaction
@@ -69,6 +70,7 @@ runInsertBench utxos =
             ]
             $ \db -> do
                 let CSMTContext{fromKV = fkv, hashing = h} = benchContext
+                    CSMTOps{csmtInsert} = mkCSMTOps fkv h
                 runner@RunTransaction{transact} <-
                     newRunRocksDBTransaction
                         db
@@ -78,7 +80,7 @@ runInsertBench utxos =
                     runner
                     benchArmageddonParams
                 forM_ utxos $ \(k, v) ->
-                    transact $ insertCSMT fkv h k v
+                    transact $ csmtInsert k v
 
 -- | RocksDB configuration
 rocksConfig :: Config

--- a/cabal.project
+++ b/cabal.project
@@ -25,9 +25,9 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/paolino/haskell-csmt
-  tag: e46ef731076cf0884d5ed0f047d0dd74e622aea8
-  --sha256: 00rmqxffkdpr4jbbz3s9pw5bqmb97jgkxzg5m235n9l364m748c0
+  location: https://github.com/paolino/haskell-mts
+  tag: e876bea60e7a4d00a4966252fac0132ad0645656
+  --sha256: 0c2ffvr3dvv6dxy0gyhwvv5424xa600cgcd5gcvms4z2xw5d249m
 
 source-repository-package
   type: git

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -75,9 +75,9 @@ library http
     , base
     , bytestring
     , cardano-utxo-csmt:library
-    , csmt
     , lens
     , memory
+    , mts:csmt
     , network
     , ouroboros-network-api
     , servant-server
@@ -129,12 +129,13 @@ library application
     , containers
     , contra-tracer
     , contra-tracer-contrib
-    , csmt
     , http-client
     , http-client-tls
     , lens
     , memory
     , mtl
+    , mts
+    , mts:csmt
     , network
     , opt-env-conf
     , ouroboros-consensus
@@ -210,6 +211,7 @@ library library
     , cardano-ledger-core
     , cardano-ledger-shelley
     , cardano-read-ledger
+    , cardano-strict-containers
     , cborg
     , cereal
     , comonad
@@ -217,7 +219,6 @@ library library
     , contra-tracer
     , contra-tracer-contrib
     , crypton
-    , csmt
     , directory
     , exceptions
     , filepath
@@ -228,6 +229,8 @@ library library
     , memory
     , mempack
     , mtl
+    , mts
+    , mts:csmt
     , network
     , network-mux
     , opt-env-conf
@@ -247,7 +250,6 @@ library library
     , serialise
     , streaming
     , streaming-bytestring
-    , cardano-strict-containers
     , strict-sop-core
     , strict-stm
     , swagger2
@@ -354,7 +356,6 @@ test-suite unit-tests
     , containers
     , contra-tracer
     , contra-tracer-contrib
-    , csmt
     , hspec
     , http-client
     , http-client-tls
@@ -362,6 +363,8 @@ test-suite unit-tests
     , lens
     , memory
     , mempack
+    , mts
+    , mts:csmt
     , opt-env-conf
     , ouroboros-network-api
     , path
@@ -440,6 +443,7 @@ test-suite e2e-tests
   build-depends:
     , base
     , bytestring
+    , cardano-ledger-byron
     , cardano-utxo-csmt:application
     , cardano-utxo-csmt:library
     , contra-tracer
@@ -468,8 +472,8 @@ benchmark bench
     , cardano-utxo-csmt:library
     , contra-tracer
     , criterion
-    , csmt
     , lens
+    , mts:csmt
     , rocksdb-haskell-jprupp
     , serialise
     , temporary

--- a/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
+++ b/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
@@ -12,6 +12,7 @@ module Cardano.UTxOCSMT.E2E.GenesisChainSyncSpec
 import Cardano.Chain.Slotting (EpochSlots (..))
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
+    , mkCSMTOps
     )
 import Cardano.UTxOCSMT.Application.Database.RocksDB
     ( createUpdateState
@@ -93,6 +94,7 @@ spec = describe "Genesis chain sync" $ do
         $ do
             let CSMTContext{fromKV = fkv, hashing = h} =
                     context
+                ops = mkCSMTOps fkv h
             withCardanoNode genesisDir
                 $ \socketPath -> do
                     withSystemTempDirectory
@@ -118,14 +120,12 @@ spec = describe "Genesis chain sync" $ do
                                             0
                                             True
                                             armageddonParams
-                                            fkv
-                                            h
+                                            ops
                                             runner
                                     (state, slots) <-
                                         createUpdateState
                                             nullTracer
-                                            fkv
-                                            h
+                                            ops
                                             slotHash
                                             (\_ _ -> pure ())
                                             armageddonParams

--- a/executables/db-query/main.hs
+++ b/executables/db-query/main.hs
@@ -88,7 +88,9 @@ queryDB dbPath txIdBytes mIndex = do
         , ("config", config)
         ]
         $ \db -> do
-            let kvCF = columnFamilies db !! 0
+            kvCF <- case columnFamilies db of
+                (cf : _) -> pure cf
+                [] -> fail "no column families"
             mapM_ (queryIndex db kvCF txIdBytes) indices
 
 queryIndex

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
@@ -1,8 +1,8 @@
 module Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( RunTransaction (..)
     , CSMTContext (..)
-    , insertCSMT
-    , deleteCSMT
+    , CSMTOps (..)
+    , mkCSMTOps
     , queryMerkleRoot
     , queryByAddress
     )
@@ -35,24 +35,32 @@ data CSMTContext hash key value = CSMTContext
     , hashing :: Hashing hash
     }
 
-insertCSMT
-    :: (Monad m, Ord key)
-    => FromKV key value hash
-    -> Hashing hash
-    -> key
-    -> value
-    -> Transaction m cf (Columns slot hash key value) op ()
-insertCSMT fkv h k v =
-    inserting fkv h KVCol CSMTCol k v
+{- | Transaction-level CSMT operations, closing over 'FromKV' and 'Hashing'.
+Serves the same role as 'MerkleTreeStore' from MTS but operates within
+the generic 'Transaction' monad with 'Columns'.
+-}
+data CSMTOps m key value hash = CSMTOps
+    { csmtInsert :: key -> value -> m ()
+    , csmtDelete :: key -> m ()
+    , csmtRootHash :: m (Maybe hash)
+    }
 
-deleteCSMT
+-- | Construct 'CSMTOps' from 'FromKV' and 'Hashing', closing over them.
+mkCSMTOps
     :: (Monad m, Ord key)
     => FromKV key value hash
     -> Hashing hash
-    -> key
-    -> Transaction m cf (Columns slot hash key value) op ()
-deleteCSMT fkv h k =
-    deleting fkv h KVCol CSMTCol k
+    -> CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
+mkCSMTOps fkv h =
+    CSMTOps
+        { csmtInsert = inserting fkv h KVCol CSMTCol
+        , csmtDelete = deleting fkv h KVCol CSMTCol
+        , csmtRootHash = root h CSMTCol
+        }
 
 queryMerkleRoot
     :: Monad m

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
@@ -16,7 +16,6 @@ module Cardano.UTxOCSMT.Application.Database.Implementation.Update
     )
 where
 
-import CSMT (FromKV, Hashing)
 import Cardano.UTxOCSMT.Application.Database.Implementation.Armageddon
     ( ArmageddonParams
     , ArmageddonTrace
@@ -31,10 +30,8 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.RollbackPoint
     , RollbackPointKV
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
-    ( RunTransaction (..)
-    , deleteCSMT
-    , insertCSMT
-    , queryMerkleRoot
+    ( CSMTOps (..)
+    , RunTransaction (..)
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
@@ -107,8 +104,11 @@ renderUpdateTrace (UpdateNewState slots) =
 newState
     :: (Ord key, Ord slot, Show slot, MonadFail m)
     => Tracer m (UpdateTrace slot hash)
-    -> FromKV key value hash
-    -> Hashing hash
+    -> CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
     -> (slot -> hash)
     -> (slot -> TipOf slot -> m ())
     -- ^ Called after each forward; use to check if at tip and emit Synced
@@ -117,8 +117,7 @@ newState
     -> m (Update m slot key value, [slot])
 newState
     TraceWith{tracer, trace}
-    fkv
-    h
+    ops
     slotHash
     onForward
     armageddonParams
@@ -130,8 +129,7 @@ newState
             $ (,cps)
             $ mkUpdate
                 tracer
-                fkv
-                h
+                ops
                 slotHash
                 onForward
                 armageddonParams
@@ -143,8 +141,11 @@ We compose csmt transactions for each operation with an updateRollbackPoint one
 forwardTip
     :: (Ord key, Ord slot, Show slot, MonadFail m)
     => Tracer m (UpdateTrace slot hash)
-    -> FromKV key value hash
-    -> Hashing hash
+    -> CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
     -> hash
     -> slot
     -- ^ slot at which operations happen
@@ -153,8 +154,7 @@ forwardTip
     -> Transaction m cf (Columns slot hash key value) op ()
 forwardTip
     TraceWith{trace}
-    fkv
-    h
+    CSMTOps{csmtInsert, csmtDelete, csmtRootHash}
     hash
     slot
     ops = do
@@ -164,11 +164,11 @@ forwardTip
         when (At slot > tip && not (null ops)) $ do
             result <- forM (zip [0 :: Int ..] ops) $ \case
                 (_, Insert k v) -> do
-                    insertCSMT fkv h k v
+                    csmtInsert k v
                     pure (Sum 1, Sum 0, [Delete k])
                 (i, Delete k) -> do
                     mx <- query KVCol k
-                    deleteCSMT fkv h k
+                    csmtDelete k
                     case mx of
                         Nothing ->
                             error
@@ -179,19 +179,21 @@ forwardTip
                                     <> show i
                         Just x -> pure (Sum 0, Sum 1, [Insert k x])
             let (Sum nInserts, Sum nDeletes, invs) = mconcat result
-            merkleRoot <- updateRollbackPoint h hash slot $ reverse invs
+            merkleRoot <-
+                updateRollbackPoint csmtRootHash hash slot $ reverse invs
             lift . lift . trace
                 $ UpdateForwardTip slot nInserts nDeletes merkleRoot
 
 updateRollbackPoint
     :: (Ord slot, Monad m)
-    => Hashing hash
+    => Transaction m cf (Columns slot hash key value) op (Maybe hash)
+    -- ^ Root hash query
     -> hash
     -> slot
     -> [Operation key value]
     -> Transaction m cf (Columns slot hash key value) op (Maybe hash)
-updateRollbackPoint h pointHash pointSlot rbpInverseOperations = do
-    rpbMerkleRoot <- queryMerkleRoot h
+updateRollbackPoint rootHashQuery pointHash pointSlot rbpInverseOperations = do
+    rpbMerkleRoot <- rootHashQuery
     insert RollbackPoints (At pointSlot)
         $ RollbackPoint
             { rbpHash = pointHash
@@ -219,15 +221,18 @@ keepAts = flip foldr [] $ \case
     At x -> (x :)
 
 rollbackRollbackPoint
-    :: (Ord key, Monad m)
-    => FromKV key value hash
-    -> Hashing hash
+    :: Monad m
+    => CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
     -> RollbackPoint slot hash key value
     -> Transaction m cf (Columns slot hash key value) op ()
-rollbackRollbackPoint fkv h RollbackPoint{rbpInverseOperations} =
+rollbackRollbackPoint CSMTOps{csmtInsert, csmtDelete} RollbackPoint{rbpInverseOperations} =
     forM_ rbpInverseOperations $ \case
-        Insert k v -> insertCSMT fkv h k v
-        Delete k -> deleteCSMT fkv h k
+        Insert k v -> csmtInsert k v
+        Delete k -> csmtDelete k
 
 -- | Result of a rollback attempt. Just a mirror, without continuation of 'Interface.State'
 data RollbackResult
@@ -246,13 +251,16 @@ If the exact rollback point is not found, we return a list of available rollback
 If the list is empty, rollback is impossible and the database should be truncated
 -}
 rollbackTip
-    :: (Ord slot, Ord key, MonadFail m)
-    => FromKV key value hash
-    -> Hashing hash
+    :: (Ord slot, MonadFail m)
+    => CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
     -> slot
     -- ^ Slot to rollback to
     -> Transaction m cf (Columns slot hash key value) op RollbackResult
-rollbackTip fkv h slot = do
+rollbackTip ops slot = do
     tip <- queryTip
     if At slot > tip
         then pure RollbackSucceeded
@@ -268,7 +276,7 @@ rollbackTip fkv h slot = do
                             Just Entry{entryKey, entryValue} ->
                                 when (entryKey > At slot) $ do
                                     lift $ do
-                                        rollbackRollbackPoint fkv h entryValue
+                                        rollbackRollbackPoint ops entryValue
                                         delete RollbackPoints entryKey
                                     prevEntry >>= go
                         pure RollbackSucceeded
@@ -297,8 +305,11 @@ of continuations and so always propose itself as the next continuation
 mkUpdate
     :: (Ord key, Ord slot, Show slot, MonadFail m)
     => Tracer m (UpdateTrace slot hash)
-    -> FromKV key value hash
-    -> Hashing hash
+    -> CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
     -> (slot -> hash)
     -> (slot -> TipOf slot -> m ())
     -- ^ Called after each forward; use to check if at tip and emit Synced
@@ -309,21 +320,21 @@ mkUpdate
     -> Update m slot key value
 mkUpdate
     TraceWith{tracer, contra}
-    fkv
-    h
+    ops
     slotHash
     onForward
     armageddonParams
     runTransaction@RunTransaction{transact} =
         fix $ \cont ->
             Update
-                { forwardTipApply = \slot chainTip ops -> do
-                    transact $ forwardTip tracer fkv h (slotHash slot) slot ops
+                { forwardTipApply = \slot chainTip operations -> do
+                    transact
+                        $ forwardTip tracer ops (slotHash slot) slot operations
                     onForward slot chainTip
                     pure cont
                 , rollbackTipApply = \case
-                    At slot -> do
-                        r <- transact $ rollbackTip fkv h slot
+                    At s -> do
+                        r <- transact $ rollbackTip ops s
                         case r of
                             RollbackSucceeded -> pure $ Syncing cont
                             -- RollbackFailedButPossible slots -> pure $ Intersecting slots cont
@@ -333,9 +344,9 @@ mkUpdate
                     Origin -> do
                         armageddonCall
                         pure $ Syncing cont
-                , forwardFinalityApply = \slot ->
+                , forwardFinalityApply = \s ->
                     transact
-                        $ forwardFinality slot >> pure cont
+                        $ forwardFinality s >> pure cont
                 }
       where
         armageddonCall =

--- a/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
@@ -18,7 +18,6 @@ module Cardano.UTxOCSMT.Application.Database.RocksDB
     )
 where
 
-import CSMT (FromKV, Hashing)
 import Cardano.UTxOCSMT.Application.Database.Implementation.Armageddon
     ( ArmageddonParams
     , setup
@@ -29,7 +28,8 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     , codecs
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
-    ( RunTransaction (..)
+    ( CSMTOps
+    , RunTransaction (..)
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
     ( UpdateTrace
@@ -88,12 +88,22 @@ newRunTransaction db prisms =
         $ codecs prisms
 
 newRocksDBState
-    :: (MonadUnliftIO m, MonadFail m, Ord key, Ord slot, Show slot, MonadMask m)
+    :: ( MonadUnliftIO m
+       , MonadFail m
+       , Ord key
+       , Ord slot
+       , Show slot
+       , MonadMask m
+       )
     => Tracer m (UpdateTrace slot hash)
     -> DB
     -> Prisms slot hash key value
-    -> FromKV key value hash
-    -> Hashing hash
+    -> CSMTOps
+        (L.Transaction m ColumnFamily (Columns slot hash key value) BatchOp)
+        key
+        value
+        hash
+    -- ^ CSMT operations (insert, delete, root hash)
     -> (slot -> hash)
     -> (slot -> TipOf slot -> m ())
     -- ^ Called after each forward; use to check if at tip and emit Synced
@@ -106,31 +116,34 @@ newRocksDBState
     tracer
     db
     prisms
-    fkv
-    h
+    ops
     slotHash
     onForward
     armageddonParams = do
         runner <- newRunRocksDBTransaction db prisms
         ensureInitialized runner armageddonParams
         (,runner)
-            <$> newState tracer fkv h slotHash onForward armageddonParams runner
+            <$> newState tracer ops slotHash onForward armageddonParams runner
 
 -- | Create Update state from an existing runner
 createUpdateState
     :: (MonadFail m, Ord key, Ord slot, Show slot)
     => Tracer m (UpdateTrace slot hash)
-    -> FromKV key value hash
-    -> Hashing hash
+    -> CSMTOps
+        (L.Transaction m ColumnFamily (Columns slot hash key value) BatchOp)
+        key
+        value
+        hash
+    -- ^ CSMT operations (insert, delete, root hash)
     -> (slot -> hash)
     -> (slot -> TipOf slot -> m ())
     -- ^ Called after each forward; use to check if at tip and emit Synced
     -> ArmageddonParams hash
     -> RunTransaction ColumnFamily BatchOp slot hash key value m
     -> m (Update m slot key value, [slot])
-createUpdateState tracer fkv h slotHash onForward armageddonParams runner = do
+createUpdateState tracer ops slotHash onForward armageddonParams runner = do
     ensureInitialized runner armageddonParams
-    newState tracer fkv h slotHash onForward armageddonParams runner
+    newState tracer ops slotHash onForward armageddonParams runner
 
 {- | Ensure the database has been initialized with an Origin rollback point.
 This makes the public API self-initializing so callers can't forget to

--- a/lib/Cardano/UTxOCSMT/Mithril/Import.hs
+++ b/lib/Cardano/UTxOCSMT/Mithril/Import.hs
@@ -22,10 +22,6 @@ module Cardano.UTxOCSMT.Mithril.Import
     )
 where
 
-import CSMT (FromKV, Hashing)
-import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
-    ( RunTransaction
-    )
 import Cardano.UTxOCSMT.Mithril.Client
     ( MithrilConfig (..)
     , MithrilError
@@ -54,7 +50,6 @@ import Control.Tracer (Tracer, contramap, traceWith)
 import Data.ByteString.Lazy (ByteString)
 import Data.Tracer.TraceWith (trace, tracer, pattern TraceWith)
 import Data.Word (Word64)
-import Database.RocksDB (BatchOp, ColumnFamily)
 import Ouroboros.Network.Block qualified as Network
 import Ouroboros.Network.Point (WithOrigin (..))
 
@@ -146,21 +141,10 @@ importFromMithril
     -- ^ Mithril client configuration
     -> IO ()
     -- ^ Action to run after download succeeds, before DB writes begin
-    -> FromKV ByteString ByteString hash
-    -- ^ Key/value codec for CSMT operations
-    -> Hashing hash
-    -- ^ Hashing operations for CSMT
-    -> RunTransaction
-        ColumnFamily
-        BatchOp
-        Point
-        hash
-        ByteString
-        ByteString
-        IO
-    -- ^ Transaction runner for database operations
+    -> (ByteString -> ByteString -> IO ())
+    -- ^ Insert a key-value pair into the CSMT database
     -> IO ImportResult
-importFromMithril TraceWith{tracer, trace} config onBeforeDbWrite fkv h runner = do
+importFromMithril TraceWith{tracer, trace} config onBeforeDbWrite insertCSMT = do
     trace ImportStarting
 
     -- Step 1: Fetch latest snapshot metadata
@@ -217,9 +201,7 @@ importFromMithril TraceWith{tracer, trace} config onBeforeDbWrite fkv h runner =
                             ( streamToCSMT
                                 (contramap ImportStreaming tracer)
                                 defaultStreamConfig
-                                fkv
-                                h
-                                runner
+                                insertCSMT
                             )
 
                     case extractResult of

--- a/lib/Cardano/UTxOCSMT/Mithril/Streaming.hs
+++ b/lib/Cardano/UTxOCSMT/Mithril/Streaming.hs
@@ -30,15 +30,10 @@ module Cardano.UTxOCSMT.Mithril.Streaming
     )
 where
 
-import CSMT (FromKV, Hashing)
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut)
 import Cardano.Ledger.Binary (natVersion, serialize)
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.TxIn (TxIn)
-import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
-    ( RunTransaction (..)
-    , insertCSMT
-    )
 import Control.Monad (when)
 import Control.Tracer (Tracer, traceWith)
 import Data.ByteString.Lazy (ByteString)
@@ -46,7 +41,6 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.MemPack (unpack)
 import Data.Time (UTCTime, diffUTCTime, getCurrentTime)
 import Data.Word (Word64)
-import Database.RocksDB (BatchOp, ColumnFamily)
 import Streaming (Of, Stream)
 import Streaming.Prelude qualified as S
 
@@ -109,19 +103,11 @@ The function:
 streamToCSMT
     :: Tracer IO StreamTrace
     -> StreamConfig
-    -> FromKV ByteString ByteString hash
-    -> Hashing hash
-    -> RunTransaction
-        ColumnFamily
-        BatchOp
-        slot
-        hash
-        ByteString
-        ByteString
-        IO
+    -> (ByteString -> ByteString -> IO ())
+    -- ^ Insert a key-value pair into the CSMT database
     -> Stream (Of (ByteString, ByteString)) IO ()
     -> IO Word64
-streamToCSMT tracer config fkv h runner stream = do
+streamToCSMT tracer config insertCSMT stream = do
     traceWith tracer StreamStarting
     startTime <- getCurrentTime
     count <- processStream startTime 0 0 stream
@@ -129,7 +115,6 @@ streamToCSMT tracer config fkv h runner stream = do
     pure count
   where
     StreamConfig{streamProgressInterval} = config
-    RunTransaction{transact} = runner
 
     processStream
         :: UTCTime
@@ -151,7 +136,7 @@ streamToCSMT tracer config fkv h runner stream = do
                         processStream startTime count (skipped + 1) rest
                     Just (cborKey, cborValue) -> do
                         -- Insert CBOR-encoded bytes into CSMT
-                        transact $ insertCSMT fkv h cborKey cborValue
+                        insertCSMT cborKey cborValue
 
                         let newCount = count + 1
 

--- a/test/Cardano/UTxOCSMT/Application/Database/E2ESpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Database/E2ESpec.hs
@@ -23,6 +23,9 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Armageddon
 import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     ( Prisms (..)
     )
+import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
+    ( mkCSMTOps
+    )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
     , State (..)
@@ -116,8 +119,7 @@ withFreshDB action =
                         nullTracer
                         db
                         testPrisms
-                        testFromKV
-                        testHashing
+                        (mkCSMTOps testFromKV testHashing)
                         testSlotHash
                         (\_ _ -> pure ())
                         testArmageddonParams
@@ -231,8 +233,8 @@ spec = describe "E2E newRocksDBState" $ do
         let hex s = case B16.decode (BC.pack s) of
                 Right bs -> bs
                 Left e -> error e
-            txIn txid ix =
-                unsafeMkTxIn (toShort $ hex txid) ix
+            txIn txid =
+                unsafeMkTxIn (toShort $ hex txid)
             -- Preprod tx hashes from Koios
             key366b_0 =
                 txIn
@@ -300,8 +302,7 @@ spec = describe "E2E newRocksDBState" $ do
                             nullTracer
                             db
                             testPrisms
-                            testFromKV
-                            testHashing
+                            (mkCSMTOps testFromKV testHashing)
                             testSlotHash
                             (\_ _ -> pure ())
                             testArmageddonParams

--- a/test/Cardano/UTxOCSMT/Application/Database/RocksDBSpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Database/RocksDBSpec.hs
@@ -39,6 +39,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Query
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
     , RunTransaction (..)
+    , mkCSMTOps
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
     ( mkUpdate
@@ -202,8 +203,7 @@ runRocksDBProperties prop =
     update =
         mkUpdate
             nullTracer
-            fkv
-            h
+            (mkCSMTOps fkv h)
             (const $ mkHash "")
             (\_ _ -> pure ())
             armageddonParams

--- a/test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
+++ b/test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
@@ -29,6 +29,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Query
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
     , RunTransaction (..)
+    , mkCSMTOps
     , queryByAddress
     , queryMerkleRoot
     )
@@ -295,8 +296,7 @@ withTestDB action =
             action runner
                 $ mkUpdate
                     nullTracer
-                    fkv
-                    h
+                    (mkCSMTOps fkv h)
                     testSlotHash
                     (\_ _ -> pure ())
                     testArmageddonParams
@@ -325,8 +325,7 @@ withTestDBPrefixed action =
             action runner
                 $ mkUpdate
                     nullTracer
-                    fkv
-                    h
+                    (mkCSMTOps fkv h)
                     testSlotHash
                     (\_ _ -> pure ())
                     testArmageddonParams

--- a/test/Cardano/UTxOCSMT/Mithril/ImportSpec.hs
+++ b/test/Cardano/UTxOCSMT/Mithril/ImportSpec.hs
@@ -21,8 +21,9 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
+    , CSMTOps (..)
     , RunTransaction (..)
-    , insertCSMT
+    , mkCSMTOps
     )
 import Cardano.UTxOCSMT.Application.Database.RocksDB
     ( newRunRocksDBTransaction
@@ -66,6 +67,7 @@ spec = describe "Mithril Import" $ do
 
                     -- Set up database with armageddon
                     let CSMTContext{fromKV = fkv, hashing = h} = csmtContext
+                        CSMTOps{csmtInsert} = mkCSMTOps fkv h
                     runner <- newRunRocksDBTransaction db prisms
                     setup nullTracer runner armageddonParams
 
@@ -73,13 +75,14 @@ spec = describe "Mithril Import" $ do
 
                     -- Insert all UTxOs from golden file
                     forM_ utxos $ \(k, v) ->
-                        transact $ insertCSMT fkv h k v
+                        transact $ csmtInsert k v
 
         it "handles empty import gracefully" $ do
             withSystemTempDirectory "import-test-empty" $ \tmpDir ->
                 withRocksDB tmpDir $ \(RunRocksDB r) -> do
                     db <- r ask
                     let CSMTContext{fromKV = fkv, hashing = h} = csmtContext
+                        CSMTOps{csmtInsert} = mkCSMTOps fkv h
                     runner <- newRunRocksDBTransaction db prisms
                     setup nullTracer runner armageddonParams
 
@@ -88,7 +91,7 @@ spec = describe "Mithril Import" $ do
                         emptyUtxos = []
 
                     forM_ emptyUtxos $ \(k, v) ->
-                        transact $ insertCSMT fkv h k v
+                        transact $ csmtInsert k v
 
 -- | CSMT context for hashing
 csmtContext :: CSMTContext Hash ByteString ByteString


### PR DESCRIPTION
Closes #121

## Summary
- Replace `haskell-csmt` with `haskell-mts` (pinned at `e876bea`)
- Bundle CSMT operations into `CSMTOps` record closing over `FromKV`/`Hashing`
- Simplify `Streaming.hs` and `Import.hs` to take `(ByteString -> ByteString -> IO ())`
- Fix pre-existing CI gaps: add hlint job, formatting diff check, e2e-tests build, missing `cardano-ledger-byron` dep

## Test plan
- [x] `just CI` passes locally (build, 106 tests, formatting, hlint, swagger, diagrams)
- [ ] GitHub Actions CI passes