### PR TITLE
fix: suppress stdout logs when metrics console is active

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -77,7 +77,7 @@ import Control.Concurrent.Class.MonadSTM.Strict
     )
 import Control.Exception (SomeException, catch, displayException)
 import Control.Monad (when, (<=<))
-import Control.Tracer (Contravariant (..), traceWith)
+import Control.Tracer (Contravariant (..), nullTracer, traceWith)
 import Data.Tracer.Intercept (intercept)
 import Data.Tracer.LogFile (logTracer)
 import Data.Tracer.ThreadSafe (newThreadSafeTracer)
@@ -130,6 +130,9 @@ main = withUtf8 $ do
             "Tracking cardano UTxOs in a CSMT in a rocksDB database"
             optionsParser
     logTracer logPath $ \basicTracer -> do
+        let appTracer
+                | metricsOn, Nothing <- logPath = nullTracer
+                | otherwise = basicTracer
         metricsVar <- newTVarIO Nothing
         metricsEvent <-
             metricsTracer
@@ -147,7 +150,7 @@ main = withUtf8 $ do
                 throttled <-
                     throttleByFrequency
                         [matchHighFrequencyEvents]
-                        (contramap renderThrottledMainTraces basicTracer)
+                        (contramap renderThrottledMainTraces appTracer)
                 newThreadSafeTracer $ timestampTracer throttled
         startHTTPService
             (trace . HTTPServiceError)


### PR DESCRIPTION
Closes #68

When `--enable-metrics-reporting` is on without `--log-path`, log messages go to stdout and corrupt the metrics console (`renderMetrics` uses `hClearScreen`/`hSetCursorPosition`).

Replace `basicTracer` with `nullTracer` when metrics are active and no log file is configured, giving the metrics console exclusive screen access. When `--log-path` is set, logs go to the file as usual.