### PR TITLE
chore: bump haskell-mts to b7696e8

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -26,8 +26,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/paolino/haskell-mts
-  tag: e876bea60e7a4d00a4966252fac0132ad0645656
-  --sha256: 0c2ffvr3dvv6dxy0gyhwvv5424xa600cgcd5gcvms4z2xw5d249m
+  tag: b7696e8d24a9d5c62efdd653d3031e77fd968116
+  --sha256: 117603f7fpga7pspb9cms6arn6g1alqvqqcfa6p7r93ri33hv25p
 
 source-repository-package
   type: git

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
@@ -86,7 +86,7 @@ mkQuery isoK =
                     Just e -> pure $ entryKey e
         , getByAddress = \addressBytes -> do
             let addressKey = byteStringToKey addressBytes
-            indirects <- collectValues CSMTCol addressKey
+            indirects <- collectValues CSMTCol [] addressKey
             catMaybes <$> traverse lookupKV indirects
         }
   where

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
@@ -57,9 +57,9 @@ mkCSMTOps
         hash
 mkCSMTOps fkv h =
     CSMTOps
-        { csmtInsert = inserting fkv h KVCol CSMTCol
-        , csmtDelete = deleting fkv h KVCol CSMTCol
-        , csmtRootHash = root h CSMTCol
+        { csmtInsert = inserting [] fkv h KVCol CSMTCol
+        , csmtDelete = deleting [] fkv h KVCol CSMTCol
+        , csmtRootHash = root h CSMTCol []
         }
 
 queryMerkleRoot
@@ -67,7 +67,7 @@ queryMerkleRoot
     => Hashing hash
     -> Transaction m cf (Columns slot hash key value) op (Maybe hash)
 queryMerkleRoot h =
-    root h CSMTCol
+    root h CSMTCol []
 
 {- | Query all UTxOs under a given address prefix.
 Uses 'collectValues' to navigate the address-prefixed CSMT,
@@ -81,7 +81,7 @@ queryByAddress
     -- ^ Address prefix as CSMT Key
     -> Transaction m cf (Columns slot hash key value) op [(key, value)]
 queryByAddress FromKV{isoK} addressKey = do
-    indirects <- collectValues CSMTCol addressKey
+    indirects <- collectValues CSMTCol [] addressKey
     catMaybes <$> traverse (lookupKV isoK) indirects
   where
     lookupKV isoK' Indirect{jump} = do

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
@@ -14,6 +14,7 @@ module Cardano.UTxOCSMT.Application.Database.Implementation.Update
     , countRollbackPoints
     , newState
     , newFinality
+    , RollbackResult (..)
     )
 where
 


### PR DESCRIPTION
## Summary
- Bumps haskell-mts to b7696e8 (prefix-scoped CSMT ops)
- Passes `[]` (empty prefix) to `inserting`, `deleting`, `root`, `collectValues` — preserving current flat-namespace behavior
- Exports `RollbackResult(..)` from `Update` module

## Test plan
- [ ] CI passes