### PR TITLE
feat: wire KVOnly→Full split-mode for faster genesis sync

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Config.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Config.hs
@@ -83,12 +83,13 @@ import Ouroboros.Network.Point qualified as Network
 
 {- | Open a RocksDB database with the required column families.
 
-The database uses four column families:
+The database uses five column families:
 
   * @kv@ - Key-value store for UTxO data
   * @csmt@ - Compact Sparse Merkle Tree nodes
   * @rollbacks@ - Rollback points for chain reorganizations
   * @config@ - Application configuration data
+  * @journal@ - Journal entries for KVOnly mode replay
 -}
 withRocksDB
     :: FilePath
@@ -104,6 +105,7 @@ withRocksDB path = do
         , ("csmt", config)
         , ("rollbacks", config)
         , ("config", config)
+        , ("journal", config)
         ]
 
 {- | Default RocksDB configuration.

--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -14,10 +14,12 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Query
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
     , RunTransaction (..)
+    , kvOnlyCSMTOps
     , mkCSMTOps
+    , replayJournal
     )
 import Cardano.UTxOCSMT.Application.Database.RocksDB
-    ( createUpdateState
+    ( createSplitUpdateState
     , newRunRocksDBTransaction
     )
 import Cardano.UTxOCSMT.Application.Metrics
@@ -78,6 +80,7 @@ import Control.Concurrent.Class.MonadSTM.Strict
 import Control.Exception (SomeException, catch, displayException)
 import Control.Monad (when, (<=<))
 import Control.Tracer (Contravariant (..), nullTracer, traceWith)
+import Data.ByteString.Lazy qualified as BL
 import Data.Tracer.Intercept (intercept)
 import Data.Tracer.LogFile (logTracer)
 import Data.Tracer.ThreadSafe (newThreadSafeTracer)
@@ -161,7 +164,9 @@ main = withUtf8 $ do
         withRocksDB dbPath $ \db -> do
             -- Create runner first (no logging)
             let CSMTContext{fromKV = fkv, hashing = h} = context
-                ops = mkCSMTOps fkv h
+                fullOps = mkCSMTOps fkv h
+                kvOps = kvOnlyCSMTOps BL.toStrict
+                ops = fullOps
             runner <-
                 newRunRocksDBTransaction
                     db
@@ -215,10 +220,19 @@ main = withUtf8 $ do
                             | blockSlot >= chainTipSlot ->
                                 traceWith metricsEvent $ BootstrapPhaseEvent Synced
                         _ -> pure ()
+                isAtTip blockPoint chainTipSlot =
+                    case pointSlot blockPoint of
+                        At blockSlot -> blockSlot >= chainTipSlot
+                        _ -> False
+                replay =
+                    replayJournal 1000 BL.fromStrict fkv h runner
             (state, slots) <-
-                createUpdateState
+                createSplitUpdateState
                     (contra Update)
-                    ops
+                    kvOps
+                    fullOps
+                    replay
+                    isAtTip
                     slotHash
                     onForward
                     armageddonParams

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs
@@ -55,12 +55,16 @@ data Columns slot hash key value x where
     ConfigCol
         :: Columns slot hash key value (KV ConfigKey ByteString)
         -- ^ Column for storing serialized application configuration
+    JournalCol
+        :: Columns slot hash key value (KV key ByteString)
+        -- ^ Journal column for KVOnly mode replay
 
 instance GEq (Columns slot hash key value) where
     geq KVCol KVCol = Just Refl
     geq CSMTCol CSMTCol = Just Refl
     geq RollbackPoints RollbackPoints = Just Refl
     geq ConfigCol ConfigCol = Just Refl
+    geq JournalCol JournalCol = Just Refl
     geq _ _ = Nothing
 
 instance GCompare (Columns slot hash key value) where
@@ -71,9 +75,13 @@ instance GCompare (Columns slot hash key value) where
     gcompare CSMTCol _ = GLT
     gcompare RollbackPoints CSMTCol = GGT
     gcompare RollbackPoints RollbackPoints = GEQ
-    gcompare RollbackPoints ConfigCol = GLT
+    gcompare RollbackPoints _ = GLT
+    gcompare ConfigCol RollbackPoints = GGT
+    gcompare ConfigCol CSMTCol = GGT
     gcompare ConfigCol ConfigCol = GEQ
-    gcompare ConfigCol _ = GGT
+    gcompare ConfigCol _ = GLT
+    gcompare JournalCol JournalCol = GEQ
+    gcompare JournalCol _ = GGT
 
 -- | Prisms for serializing/deserializing keys and values
 data Prisms slot hash key value = Prisms
@@ -99,6 +107,11 @@ codecs Prisms{keyP, hashP, slotP, valueP} =
         , ConfigCol
             :=> Codecs
                 { keyCodec = configKeyPrism
+                , valueCodec = prism' id Just
+                }
+        , JournalCol
+            :=> Codecs
+                { keyCodec = keyP
                 , valueCodec = prism' id Just
                 }
         ]

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
@@ -3,22 +3,43 @@ module Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , CSMTContext (..)
     , CSMTOps (..)
     , mkCSMTOps
+    , kvOnlyCSMTOps
+    , replayJournal
+    , journalEmpty
     , queryMerkleRoot
     , queryByAddress
     )
 where
 
-import CSMT (FromKV (..), Hashing, inserting)
-import CSMT.Deletion (deleting)
+import CSMT
+    ( FromKV (..)
+    , Hashing
+    , inserting
+    , insertingTreeOnly
+    )
+import CSMT.Deletion (deleting, deletingTreeOnly)
 import CSMT.Interface (Indirect (..), Key, root)
 import CSMT.Proof.Completeness (collectValues)
 import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     ( Columns (..)
     )
 import Control.Lens (review)
-import Data.Maybe (catMaybes)
+import Control.Monad (unless)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as B
+import Data.Maybe (catMaybes, isNothing)
+import Database.KV.Cursor
+    ( Cursor
+    , Entry (..)
+    , firstEntry
+    , nextEntry
+    )
 import Database.KV.Transaction
-    ( Transaction
+    ( KV
+    , Transaction
+    , delete
+    , insert
+    , iterating
     , query
     )
 
@@ -61,6 +82,138 @@ mkCSMTOps fkv h =
         , csmtDelete = deleting [] fkv h KVCol CSMTCol
         , csmtRootHash = root h CSMTCol []
         }
+
+{- | Construct KVOnly 'CSMTOps' that writes to the KV store and
+journal but does not update the CSMT tree. Root hash always
+returns 'Nothing'.
+
+The journal records each mutation so that 'replayJournal' can
+later rebuild the tree in one pass.
+-}
+kvOnlyCSMTOps
+    :: (Monad m, Ord key)
+    => (value -> ByteString)
+    -- ^ Serialize value for journal storage
+    -> CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
+kvOnlyCSMTOps serializeValue =
+    CSMTOps
+        { csmtInsert = \k v -> do
+            insert KVCol k v
+            insert JournalCol k
+                $ journalInsertTag <> serializeValue v
+        , csmtDelete = \k -> do
+            mv <- query KVCol k
+            case mv of
+                Nothing -> pure ()
+                Just v -> do
+                    delete KVCol k
+                    insert JournalCol k
+                        $ journalDeleteTag
+                            <> serializeValue v
+        , csmtRootHash = pure Nothing
+        }
+
+-- | Journal tag for insert entries.
+journalInsertTag :: ByteString
+journalInsertTag = B.singleton 0x01
+
+-- | Journal tag for delete entries.
+journalDeleteTag :: ByteString
+journalDeleteTag = B.singleton 0x00
+
+{- | Replay all journal entries against the CSMT tree, then
+clear the journal. Processes in chunks of @chunkSize@ entries.
+-}
+replayJournal
+    :: (Monad m, Ord key)
+    => Int
+    -- ^ Chunk size
+    -> (ByteString -> value)
+    -- ^ Deserialize value from journal storage
+    -> FromKV key value hash
+    -> Hashing hash
+    -> RunTransaction cf op slot hash key value m
+    -> m ()
+replayJournal chunkSize deserializeValue fkv h RunTransaction{transact} =
+    loop
+  where
+    loop = do
+        done <- transact $ do
+            entries <- iterating JournalCol $ do
+                me <- firstEntry
+                case me of
+                    Nothing -> pure []
+                    Just e -> collectN (chunkSize - 1) [e]
+            if null entries
+                then pure True
+                else do
+                    replayEntries fkv h deserializeValue entries
+                    pure False
+        unless done loop
+
+-- | Collect up to @n@ more cursor entries after the first.
+collectN
+    :: Monad m
+    => Int
+    -> [Entry c]
+    -> Cursor
+        (Transaction m cf (Columns slot hash key value) op)
+        c
+        [Entry c]
+collectN 0 acc = pure (reverse acc)
+collectN n acc = do
+    me <- nextEntry
+    case me of
+        Nothing -> pure (reverse acc)
+        Just e -> collectN (n - 1) (e : acc)
+
+-- | Apply journal entries to the tree and delete them.
+replayEntries
+    :: (Monad m, Ord key)
+    => FromKV key value hash
+    -> Hashing hash
+    -> (ByteString -> value)
+    -> [Entry (KV key ByteString)]
+    -> Transaction
+        m
+        cf
+        (Columns slot hash key value)
+        op
+        ()
+replayEntries fkv h deserializeValue entries = do
+    mapM_ applyEntry entries
+    mapM_ (delete JournalCol . entryKey) entries
+  where
+    applyEntry e =
+        let (tag, vBytes) = parseJournalEntry (entryValue e)
+            k = entryKey e
+            v = deserializeValue vBytes
+        in  case tag of
+                JInsert ->
+                    insertingTreeOnly [] fkv h CSMTCol k v
+                JDelete ->
+                    deletingTreeOnly [] fkv h CSMTCol k v
+
+-- | Tag for journal entries.
+data JournalTag = JInsert | JDelete
+
+-- | Parse a journal entry into tag and value payload.
+parseJournalEntry :: ByteString -> (JournalTag, ByteString)
+parseJournalEntry bs = case B.uncons bs of
+    Just (0x01, rest) -> (JInsert, rest)
+    Just (0x00, rest) -> (JDelete, rest)
+    _ -> error "parseJournalEntry: invalid tag byte"
+
+-- | Check if the journal column is empty.
+journalEmpty
+    :: Monad m
+    => Transaction m cf (Columns slot hash key value) op Bool
+journalEmpty =
+    iterating JournalCol $ isNothing <$> firstEntry
 
 queryMerkleRoot
     :: Monad m

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
@@ -1,5 +1,7 @@
 module Cardano.UTxOCSMT.Application.Database.Implementation.Update
     ( mkUpdate
+    , mkSplitUpdate
+    , newSplitState
 
       -- * Tracing
     , UpdateTrace (..)
@@ -31,6 +33,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.RollbackPoint
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTOps (..)
     , RunTransaction (..)
+    , journalEmpty
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
@@ -83,6 +86,7 @@ data UpdateTrace slot hash
     = UpdateArmageddon ArmageddonTrace
     | UpdateForwardTip slot Int Int (Maybe hash)
     | UpdateNewState [slot]
+    | UpdateJournalReplay
     deriving (Show)
 
 renderUpdateTrace :: Show slot => UpdateTrace slot hash -> String
@@ -97,6 +101,8 @@ renderUpdateTrace (UpdateForwardTip slot nInsert nDelete _merkleRoot) =
         ++ " deletes"
 renderUpdateTrace (UpdateNewState slots) =
     "New update state with rollback points at: " ++ show slots
+renderUpdateTrace UpdateJournalReplay =
+    "Replaying journal to build CSMT tree"
 
 newState
     :: (Ord key, Ord slot, Show slot, MonadFail m)
@@ -139,6 +145,83 @@ newState
                 armageddonParams
                 runTransaction
                 rollbackCount
+
+{- | Initialize split-mode state.
+
+If the journal is non-empty, start in KVOnly mode (will replay
+on first tip touch). If empty, start in Full mode directly.
+-}
+newSplitState
+    :: (Ord key, Ord slot, Show slot, MonadFail m)
+    => Tracer m (UpdateTrace slot hash)
+    -> CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
+    -- ^ KVOnly ops (phase 1)
+    -> CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
+    -- ^ Full ops (phase 2)
+    -> m ()
+    -- ^ Replay callback
+    -> (slot -> TipOf slot -> Bool)
+    -- ^ Tip detection predicate
+    -> (slot -> hash)
+    -> (slot -> TipOf slot -> m ())
+    -> ArmageddonParams hash
+    -> RunTransaction cf op slot hash key value m
+    -> m (Update m slot key value, [slot])
+newSplitState
+    tw@TraceWith{tracer, trace}
+    kvOps
+    fullOps
+    replay
+    isAtTip
+    slotHash
+    onForward
+    armageddonParams
+    runTransaction@RunTransaction{transact} = do
+        (cps, rollbackCount, empty) <-
+            transact $ do
+                cps <-
+                    iterating
+                        RollbackPoints
+                        sampleRollbackPoints
+                rollbackCount <-
+                    Store.countPoints RollbackPoints
+                empty <- journalEmpty
+                pure (cps, rollbackCount, empty)
+        trace $ UpdateNewState cps
+        if empty
+            then
+                pure
+                    $ (,cps)
+                    $ mkUpdate
+                        tracer
+                        fullOps
+                        slotHash
+                        onForward
+                        armageddonParams
+                        runTransaction
+                        rollbackCount
+            else
+                pure
+                    $ (,cps)
+                    $ mkSplitUpdate
+                        tw
+                        kvOps
+                        fullOps
+                        replay
+                        isAtTip
+                        slotHash
+                        onForward
+                        armageddonParams
+                        runTransaction
+                        rollbackCount
 
 {- | Apply forward tip .
 We compose csmt transactions for each operation with an updateRollbackPoint one
@@ -349,6 +432,130 @@ mkUpdate
                     pure
                         $ go (count - pruned)
                 }
+        armageddonCall =
+            armageddon
+                (contra UpdateArmageddon)
+                runTransaction
+                armageddonParams
+
+{- | Two-phase update: starts in KVOnly mode, switches to Full
+after replaying the journal on first tip-touch.
+
+The follower is blocked during replay (forwardTipApply runs
+synchronously), making the transition atomic w.r.t. chain sync.
+-}
+mkSplitUpdate
+    :: (Ord key, Ord slot, Show slot, MonadFail m)
+    => Tracer m (UpdateTrace slot hash)
+    -> CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
+    -- ^ KVOnly ops (phase 1)
+    -> CSMTOps
+        (Transaction m cf (Columns slot hash key value) op)
+        key
+        value
+        hash
+    -- ^ Full ops (phase 2)
+    -> m ()
+    -- ^ Replay callback
+    -> (slot -> TipOf slot -> Bool)
+    -- ^ Tip detection predicate
+    -> (slot -> hash)
+    -> (slot -> TipOf slot -> m ())
+    -- ^ Called after each forward
+    -> ArmageddonParams hash
+    -> RunTransaction cf op slot hash key value m
+    -> Int
+    -- ^ Initial rollback point count
+    -> Update m slot key value
+mkSplitUpdate
+    TraceWith{tracer, contra, trace}
+    kvOps
+    fullOps
+    replay
+    isAtTip
+    slotHash
+    onForward
+    armageddonParams
+    runTransaction@RunTransaction{transact} =
+        goKVOnly
+      where
+        goKVOnly count =
+            Update
+                { forwardTipApply =
+                    \slot chainTip operations -> do
+                        stored <-
+                            transact
+                                $ forwardTip
+                                    tracer
+                                    kvOps
+                                    (slotHash slot)
+                                    count
+                                    slot
+                                    operations
+                        onForward slot chainTip
+                        let count' =
+                                if stored
+                                    then count + 1
+                                    else count
+                        if isAtTip slot chainTip
+                            then do
+                                trace UpdateJournalReplay
+                                replay
+                                pure $ goFull count'
+                            else
+                                pure $ goKVOnly count'
+                , rollbackTipApply = \case
+                    At s -> do
+                        r <-
+                            transact $ do
+                                tip <- queryTip
+                                if At s > tip
+                                    then
+                                        pure
+                                            $ Store.RollbackSucceeded
+                                                0
+                                    else
+                                        Store.rollbackTo
+                                            RollbackPoints
+                                            ( rollbackRollbackPoint
+                                                kvOps
+                                            )
+                                            (At s)
+                        case r of
+                            Store.RollbackSucceeded deleted ->
+                                pure
+                                    $ Syncing
+                                    $ goKVOnly
+                                        (count - deleted)
+                            Store.RollbackImpossible -> do
+                                armageddonCall
+                                pure
+                                    $ Truncating
+                                    $ goKVOnly 0
+                    Origin -> do
+                        armageddonCall
+                        pure $ Syncing $ goKVOnly 0
+                , forwardFinalityApply = \s -> do
+                    pruned <-
+                        transact
+                            $ Store.pruneBelow
+                                RollbackPoints
+                                (At s)
+                    pure
+                        $ goKVOnly (count - pruned)
+                }
+        goFull =
+            mkUpdate
+                tracer
+                fullOps
+                slotHash
+                onForward
+                armageddonParams
+                runTransaction
         armageddonCall =
             armageddon
                 (contra UpdateArmageddon)

--- a/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
@@ -15,6 +15,7 @@ module Cardano.UTxOCSMT.Application.Database.RocksDB
     , newRunRocksDBTransaction
     , newRocksDBState
     , createUpdateState
+    , createSplitUpdateState
     )
 where
 
@@ -33,6 +34,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
     ( UpdateTrace
+    , newSplitState
     , newState
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
@@ -144,6 +146,56 @@ createUpdateState
 createUpdateState tracer ops slotHash onForward armageddonParams runner = do
     ensureInitialized runner armageddonParams
     newState tracer ops slotHash onForward armageddonParams runner
+
+{- | Create split-mode Update state from an existing runner.
+
+Starts in KVOnly mode if journal is non-empty, otherwise Full.
+-}
+createSplitUpdateState
+    :: (MonadFail m, Ord key, Ord slot, Show slot)
+    => Tracer m (UpdateTrace slot hash)
+    -> CSMTOps
+        (L.Transaction m ColumnFamily (Columns slot hash key value) BatchOp)
+        key
+        value
+        hash
+    -- ^ KVOnly ops
+    -> CSMTOps
+        (L.Transaction m ColumnFamily (Columns slot hash key value) BatchOp)
+        key
+        value
+        hash
+    -- ^ Full ops
+    -> m ()
+    -- ^ Replay callback
+    -> (slot -> TipOf slot -> Bool)
+    -- ^ Tip detection predicate
+    -> (slot -> hash)
+    -> (slot -> TipOf slot -> m ())
+    -> ArmageddonParams hash
+    -> RunTransaction ColumnFamily BatchOp slot hash key value m
+    -> m (Update m slot key value, [slot])
+createSplitUpdateState
+    tracer
+    kvOps
+    fullOps
+    replay
+    isAtTip
+    slotHash
+    onForward
+    armageddonParams
+    runner = do
+        ensureInitialized runner armageddonParams
+        newSplitState
+            tracer
+            kvOps
+            fullOps
+            replay
+            isAtTip
+            slotHash
+            onForward
+            armageddonParams
+            runner
 
 {- | Ensure the database has been initialized with an Origin rollback point.
 This makes the public API self-initializing so callers can't forget to


### PR DESCRIPTION
## Summary

- Add KVOnly→Full split-mode to avoid building the CSMT tree during from-genesis sync
- Sync in KVOnly mode (KV + journal writes, no tree updates) until reaching chain tip
- On first tip-touch, replay journal inline to build the tree, then switch to Full mode
- On restart, check journal: non-empty → split mode, empty → Full mode directly

## Changes

- `Columns.hs`: add `JournalCol` to the GADT
- `Config.hs`: add `journal` column family to RocksDB
- `Transaction.hs`: add `kvOnlyCSMTOps`, `replayJournal`, `journalEmpty`
- `Update.hs`: add `mkSplitUpdate` (two-phase closure), `newSplitState`, `UpdateJournalReplay` trace
- `RocksDB.hs`: add `createSplitUpdateState`
- `Main.hs`: wire split mode with `isAtTip` predicate and replay callback

## Test plan

- [x] `just build` — compiles
- [x] `just unit` — 108 tests pass (use Full mode, unaffected)
- [x] `fourmolu -m check` — formatting clean
- [x] `hlint` — no hints
- [ ] Build docker image, deploy to production
- [ ] Verify logs: KVOnly sync → "Replaying journal" → Full mode
- [ ] After replay, API serves merkle proofs (trie is built)