### PR TITLE
feat: measureDuration-based timing, wire BenchOps flags

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Config.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Config.hs
@@ -121,7 +121,7 @@ config =
         , paranoidChecks = False
         , maxFiles = Nothing
         , prefixLength = Nothing
-        , bloomFilter = False
+        , bloomFilter = True
         }
 
 {- | Parameters for the armageddon (database reset) operation.
@@ -304,7 +304,7 @@ mFinality (RunTransaction runTx) =
         -> WithOrigin Point
         -> Bool
     isFinal tip finality =
-        distance tip finality > 2160
+        distance tip finality > 2160 * 20
 
 {- | Calculate the slot distance between two points.
 

--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -18,6 +18,10 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , mkCSMTOps
     , replayJournal
     )
+import Cardano.UTxOCSMT.Application.Database.Implementation.Update
+    ( allOps
+    , measureUpdateDurations
+    )
 import Cardano.UTxOCSMT.Application.Database.RocksDB
     ( createSplitUpdateState
     , newRunRocksDBTransaction
@@ -81,11 +85,12 @@ import Control.Exception (SomeException, catch, displayException)
 import Control.Monad (when, (<=<))
 import Control.Tracer (Contravariant (..), nullTracer, traceWith)
 import Data.ByteString.Lazy qualified as BL
+import Data.Time.Clock (diffUTCTime)
 import Data.Tracer.Intercept (intercept)
 import Data.Tracer.LogFile (logTracer)
 import Data.Tracer.ThreadSafe (newThreadSafeTracer)
 import Data.Tracer.Throttle (throttleByFrequency)
-import Data.Tracer.Timestamp (timestampTracer)
+import Data.Tracer.Timestamp (utcTimestampTracer)
 import Data.Tracer.TraceWith
     ( contra
     , trace
@@ -152,9 +157,10 @@ main = withUtf8 $ do
             fmap (intercept metricsEvent stealMetricsEvent) $ do
                 throttled <-
                     throttleByFrequency
+                        (\t1 t2 -> realToFrac (diffUTCTime t2 t1))
                         [matchHighFrequencyEvents]
                         (contramap renderThrottledMainTraces appTracer)
-                newThreadSafeTracer $ timestampTracer throttled
+                newThreadSafeTracer $ utcTimestampTracer throttled
         startHTTPService
             (trace . HTTPServiceError)
             (trace ServeDocs)
@@ -198,7 +204,7 @@ main = withUtf8 $ do
                             (n2nHost, n2nPort, skipNodeValidation options)
                         N2C{} ->
                             ("localhost", 0, True)
-            SetupResult{setupStartingPoint, setupMithrilSlot} <-
+            SetupResult{setupStartingPoint, setupMithrilSlot, setupIsGenesis} <-
                 setupDB
                     tracer
                     startingPoint
@@ -226,9 +232,13 @@ main = withUtf8 $ do
                         _ -> False
                 replay =
                     replayJournal 1000 BL.fromStrict fkv h runner
+            updateTracer <-
+                measureUpdateDurations (contra Update)
             (state, slots) <-
                 createSplitUpdateState
-                    (contra Update)
+                    updateTracer
+                    allOps
+                    setupIsGenesis
                     kvOps
                     fullOps
                     replay

--- a/application/Cardano/UTxOCSMT/Application/Run/RenderMetrics.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/RenderMetrics.hs
@@ -36,6 +36,12 @@ renderMetrics
         , extractionProgress
         , downloadedBytes
         , countingProgress
+        , avgCSMTDuration
+        , avgRollbackDuration
+        , avgFinalityDuration
+        , avgBlockDecodeDuration
+        , avgTransactionDuration
+        , avgTotalBlockDuration
         } = do
         hClearScreen stdout
         hSetCursorPosition stdout 0 0
@@ -68,6 +74,24 @@ renderMetrics
                 ++ maybe "N/A" show currentMerkleRoot
                 ++ "\nCurrent Era: "
                 ++ fromMaybe "N/A" currentEra
+                ++ "\nAvg CSMT Duration: "
+                ++ printf "%.0f" avgCSMTDuration
+                ++ " μs"
+                ++ "\nAvg Rollback Duration: "
+                ++ printf "%.0f" avgRollbackDuration
+                ++ " μs"
+                ++ "\nAvg Finality Duration: "
+                ++ printf "%.0f" avgFinalityDuration
+                ++ " μs"
+                ++ "\nAvg Block Decode: "
+                ++ printf "%.0f" avgBlockDecodeDuration
+                ++ " μs"
+                ++ "\nAvg Transaction: "
+                ++ printf "%.0f" avgTransactionDuration
+                ++ " μs"
+                ++ "\nAvg Total Block: "
+                ++ printf "%.0f" avgTotalBlockDuration
+                ++ " μs"
 
 renderDownloadProgress :: Maybe Word64 -> String
 renderDownloadProgress Nothing = "N/A"

--- a/application/Cardano/UTxOCSMT/Application/Run/Setup.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Setup.hs
@@ -100,6 +100,8 @@ data SetupResult = SetupResult
     -- ^ Starting point for chain sync (Origin or Mithril checkpoint)
     , setupMithrilSlot :: Maybe Word64
     -- ^ If bootstrapped from Mithril, the slot to skip headers until
+    , setupIsGenesis :: Bool
+    -- ^ True if the DB was freshly initialized (no prior data)
     }
 
 {- | Set up the database, potentially bootstrapping from Mithril or genesis.
@@ -207,6 +209,7 @@ setupDB
                             SetupResult
                                 { setupStartingPoint = point
                                 , setupMithrilSlot = skipSlot
+                                , setupIsGenesis = False
                                 }
       where
         -- \| Validate node connection, returning True if OK or skipped
@@ -263,6 +266,7 @@ setupDB
                     SetupResult
                         { setupStartingPoint = startingPoint
                         , setupMithrilSlot = Nothing
+                        , setupIsGenesis = True
                         }
 
         genesisSetup = do
@@ -289,6 +293,7 @@ setupDB
                 SetupResult
                     { setupStartingPoint = originPoint
                     , setupMithrilSlot = Nothing
+                    , setupIsGenesis = True
                     }
 
         bootstrapFromMithril = do
@@ -377,6 +382,7 @@ setupDB
                                 SetupResult
                                     { setupStartingPoint = importCheckpoint
                                     , setupMithrilSlot = Just importSlot
+                                    , setupIsGenesis = True
                                     }
                         ImportFailed err -> do
                             trace $ Mithril $ ImportError err

--- a/application/Cardano/UTxOCSMT/Application/Run/Traces.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Traces.hs
@@ -24,7 +24,12 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Armageddon
     , renderArmageddonTrace
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
-    ( UpdateTrace (UpdateForwardTip)
+    ( UpdateTrace
+        ( UpdateCSMTMeasured
+        , UpdateFinalityMeasured
+        , UpdateRollbackMeasured
+        , UpdateTransactMeasured
+        )
     , renderUpdateTrace
     )
 import Cardano.UTxOCSMT.Application.Metrics
@@ -54,6 +59,7 @@ import Cardano.UTxOCSMT.Ouroboros.Connection
     ( NodeConnectionError (..)
     )
 import Cardano.UTxOCSMT.Ouroboros.Types (Point)
+import Data.Time.Clock (UTCTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.Tracer.Throttle (Throttled (..))
 import Data.Tracer.Timestamp (Timestamped (..))
@@ -169,16 +175,21 @@ renderNodeConnectionError NodeConnectionTimeout =
 
 This function is used with the trace interceptor to forward relevant
 events to the metrics system without modifying the trace pipeline.
-Returns 'Just' for traces that should trigger metrics updates,
-'Nothing' otherwise.
+Returns a list of metrics events to emit (empty = no interception).
 -}
 stealMetricsEvent
     :: MainTraces
     -- ^ The trace to inspect
     -> Maybe MetricsEvent
-    -- ^ Corresponding metrics event, if any
-stealMetricsEvent (Update (UpdateForwardTip _ _ _ (Just merkleRoot))) =
-    Just $ MerkleRootEvent merkleRoot
+    -- ^ Corresponding metrics event
+stealMetricsEvent (Update (UpdateCSMTMeasured _ _ _ ns)) =
+    Just $ CSMTDurationEvent ns
+stealMetricsEvent (Update (UpdateRollbackMeasured _ _ _ _ ns)) =
+    Just $ RollbackDurationEvent ns
+stealMetricsEvent (Update (UpdateFinalityMeasured _ _ ns)) =
+    Just $ FinalityDurationEvent ns
+stealMetricsEvent (Update (UpdateTransactMeasured _ secs)) =
+    Just $ TransactionDurationEvent secs
 stealMetricsEvent (NotEmpty point) =
     Just $ BaseCheckpointEvent point
 stealMetricsEvent (Application (ApplicationRollingBack _)) =
@@ -210,14 +221,17 @@ matchHighFrequencyEvents = \case
     Mithril (ImportMithril (MithrilDownloadProgress _)) -> Just 1.0
     Mithril (ImportExtraction (ExtractionCounting _)) -> Just 1.0
     Mithril (ImportExtraction (ExtractionProgress _)) -> Just 1.0
-    Update (UpdateForwardTip{}) -> Just 1.0
+    Update (UpdateCSMTMeasured{}) -> Just 1.0
+    Update (UpdateRollbackMeasured{}) -> Just 1.0
+    Update (UpdateFinalityMeasured{}) -> Just 1.0
+    Update (UpdateTransactMeasured{}) -> Just 1.0
     _ -> Nothing
 
 {- | Render a throttled 'MainTraces' value to a log string.
 
 Includes timestamp and drop count information when events were throttled.
 -}
-renderThrottledMainTraces :: Throttled MainTraces -> String
+renderThrottledMainTraces :: Throttled UTCTime MainTraces -> String
 renderThrottledMainTraces Throttled{throttledEvent, throttledDropped} =
     let Timestamped{timestampedTime, timestampedEvent} = throttledEvent
         baseMsg = renderMainTraces timestampedEvent
@@ -225,7 +239,7 @@ renderThrottledMainTraces Throttled{throttledEvent, throttledDropped} =
             "["
                 ++ formatTime
                     defaultTimeLocale
-                    "%Y-%m-%d %H:%M:%S"
+                    "%Y-%m-%d %H:%M:%S%Q"
                     timestampedTime
                 ++ "] "
         droppedSuffix

--- a/bench/Bench/CSMT.hs
+++ b/bench/Bench/CSMT.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 {- |
 Module      : Bench.CSMT
 Description : CSMT insertion benchmarks
@@ -8,6 +10,14 @@ Note: Includes DB setup time as RocksDB uses bracket pattern.
 module Bench.CSMT
     ( loadGoldenUtxos
     , runInsertBench
+    , runKVOnlyInsertBench
+    , runKVOnlySmallBatchBench
+    , runPureSerializationBench
+    , runKVOnlyInternalTimingBench
+    , runKVOnlyPrePopulatedBench
+    , runRepeatedTransactionsBench
+    , runForwardTipStyleBench
+    , runStressBench
     )
 where
 
@@ -30,22 +40,41 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
     , CSMTOps (..)
     , RunTransaction (..)
+    , kvOnlyCSMTOps
     , mkCSMTOps
     )
+import Cardano.UTxOCSMT.Application.Database.Implementation.Update
+    ( BenchOps (..)
+    , UpdateTrace
+    )
+import Cardano.UTxOCSMT.Application.Database.Interface
+    ( Operation (..)
+    , Update (..)
+    )
 import Cardano.UTxOCSMT.Application.Database.RocksDB
-    ( newRunRocksDBTransaction
+    ( createUpdateState
+    , newRunRocksDBTransaction
     )
 import Codec.Serialise (deserialise)
 import Control.Lens (Prism', lazy, prism', strict, view)
-import Control.Monad (forM_)
-import Control.Tracer (nullTracer)
+import Control.Monad (forM, forM_, void, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans (lift)
+import Control.Tracer (Tracer, nullTracer)
+import Data.Bits (shiftR, (.&.))
 import Data.ByteString (StrictByteString)
+import Data.ByteString qualified as B
 import Data.ByteString.Lazy (ByteString)
 import Data.ByteString.Lazy qualified as LBS
+import Data.List (foldl')
+import Data.Monoid (Sum (..))
+import Data.Word (Word64)
+import Database.KV.Transaction (Transaction)
 import Database.RocksDB
     ( Config (..)
     , withDBCF
     )
+import GHC.Clock (getMonotonicTimeNSec)
 import System.IO.Temp (withSystemTempDirectory)
 
 -- | Load golden UTxOs from file
@@ -123,6 +152,390 @@ benchContext =
         , hashing = hashHashing
         }
 
+-- | KVOnly insertion benchmark — all inserts in one transaction
+runKVOnlyInsertBench
+    :: [(ByteString, ByteString)]
+    -> IO ()
+runKVOnlyInsertBench utxos =
+    withSystemTempDirectory "csmt-bench" $ \tmpDir ->
+        withDBCF
+            tmpDir
+            rocksConfig
+            [ ("kv", rocksConfig)
+            , ("csmt", rocksConfig)
+            , ("rollbacks", rocksConfig)
+            , ("config", rocksConfig)
+            , ("journal", rocksConfig)
+            ]
+            $ \db -> do
+                let CSMTOps{csmtInsert} =
+                        kvOnlyCSMTOps (view strict)
+                runner@RunTransaction{transact} <-
+                    newRunRocksDBTransaction
+                        db
+                        benchPrisms
+                setup
+                    nullTracer
+                    runner
+                    benchArmageddonParams
+                transact
+                    $ forM_ utxos
+                    $ uncurry csmtInsert
+
+-- | KVOnly insertion benchmark — small batches like production
+runKVOnlySmallBatchBench
+    :: Int
+    -> [(ByteString, ByteString)]
+    -> IO ()
+runKVOnlySmallBatchBench batchSize utxos =
+    withSystemTempDirectory "csmt-bench" $ \tmpDir ->
+        withDBCF
+            tmpDir
+            rocksConfig
+            [ ("kv", rocksConfig)
+            , ("csmt", rocksConfig)
+            , ("rollbacks", rocksConfig)
+            , ("config", rocksConfig)
+            , ("journal", rocksConfig)
+            ]
+            $ \db -> do
+                let CSMTOps{csmtInsert} =
+                        kvOnlyCSMTOps (view strict)
+                runner@RunTransaction{transact} <-
+                    newRunRocksDBTransaction
+                        db
+                        benchPrisms
+                setup
+                    nullTracer
+                    runner
+                    benchArmageddonParams
+                forM_ (chunksOf batchSize utxos)
+                    $ \chunk ->
+                        transact
+                            $ forM_ chunk
+                            $ uncurry csmtInsert
+
+-- | Pure serialization benchmark — no DB, just BL.toStrict + tag
+runPureSerializationBench
+    :: [(ByteString, ByteString)]
+    -> IO Int
+runPureSerializationBench utxos =
+    pure
+        $! foldl'
+            ( \acc (k, v) ->
+                let !sk = LBS.toStrict k
+                    !sv = B.singleton 0x01 <> LBS.toStrict v
+                in  acc + B.length sk + B.length sv
+            )
+            0
+            utxos
+
+-- | Benchmark with internal timing — measures only in-txn time
+runKVOnlyInternalTimingBench
+    :: Int
+    -> [(ByteString, ByteString)]
+    -> IO Double
+runKVOnlyInternalTimingBench batchSize utxos =
+    withSystemTempDirectory "csmt-bench" $ \tmpDir ->
+        withDBCF
+            tmpDir
+            rocksConfig
+            [ ("kv", rocksConfig)
+            , ("csmt", rocksConfig)
+            , ("rollbacks", rocksConfig)
+            , ("config", rocksConfig)
+            , ("journal", rocksConfig)
+            ]
+            $ \db -> do
+                let CSMTOps{csmtInsert} =
+                        kvOnlyCSMTOps (view strict)
+                    clock
+                        :: Transaction
+                            IO
+                            cf
+                            cols
+                            op
+                            Word64
+                    clock = lift (lift (liftIO getMonotonicTimeNSec))
+                runner@RunTransaction{transact} <-
+                    newRunRocksDBTransaction
+                        db
+                        benchPrisms
+                setup
+                    nullTracer
+                    runner
+                    benchArmageddonParams
+                totalNs <- fmap sum
+                    $ forM (chunksOf batchSize utxos)
+                    $ \chunk -> transact $ do
+                        t1 <- clock
+                        result <-
+                            forM
+                                (zip [0 :: Int ..] chunk)
+                                $ \(_, (k, v)) -> do
+                                    csmtInsert k v
+                                    pure (Sum (1 :: Int), Sum (0 :: Int), [k])
+                        let (Sum _nI, Sum _nD, _invs) =
+                                mconcat result
+                        t2 <- clock
+                        pure (t2 - t1)
+                pure
+                    $ fromIntegral totalNs
+                        / (1000 * fromIntegral (length utxos))
+
+-- | Benchmark with pre-populated DB — reproduces production conditions
+runKVOnlyPrePopulatedBench
+    :: Int
+    -- ^ Number of rounds to pre-populate (each round = 1000 UTxOs)
+    -> Int
+    -- ^ Batch size for measurement
+    -> [(ByteString, ByteString)]
+    -> IO Double
+runKVOnlyPrePopulatedBench rounds batchSize utxos =
+    withSystemTempDirectory "csmt-bench" $ \tmpDir ->
+        withDBCF
+            tmpDir
+            rocksConfig
+            [ ("kv", rocksConfig)
+            , ("csmt", rocksConfig)
+            , ("rollbacks", rocksConfig)
+            , ("config", rocksConfig)
+            , ("journal", rocksConfig)
+            ]
+            $ \db -> do
+                let CSMTOps{csmtInsert} =
+                        kvOnlyCSMTOps (view strict)
+                    clock
+                        :: Transaction
+                            IO
+                            cf
+                            cols
+                            op
+                            Word64
+                    clock = lift (lift (liftIO getMonotonicTimeNSec))
+                runner@RunTransaction{transact} <-
+                    newRunRocksDBTransaction
+                        db
+                        benchPrisms
+                setup
+                    nullTracer
+                    runner
+                    benchArmageddonParams
+                -- Pre-populate: insert rounds × 1000 entries
+                forM_ [1 .. rounds] $ \r -> do
+                    let prefix =
+                            LBS.fromStrict
+                                $ B.pack
+                                    [ fromIntegral (r `div` 256)
+                                    , fromIntegral (r `mod` 256)
+                                    ]
+                    transact
+                        $ forM_ utxos
+                        $ \(k, v) ->
+                            csmtInsert (prefix <> k) v
+                    when (r `mod` 100 == 0)
+                        $ putStrLn
+                        $ "  pre-populated "
+                            ++ show (r * length utxos)
+                            ++ " entries"
+                -- Now measure on top of populated DB
+                let measureUtxos =
+                        [ (LBS.fromStrict (B.pack [0xFF, 0xFF]) <> k, v)
+                        | (k, v) <- utxos
+                        ]
+                totalNs <- fmap sum
+                    $ forM (chunksOf batchSize measureUtxos)
+                    $ \chunk -> transact $ do
+                        t1 <- clock
+                        result <-
+                            forM
+                                (zip [0 :: Int ..] chunk)
+                                $ \(_, (k, v)) -> do
+                                    csmtInsert k v
+                                    pure (Sum (1 :: Int), Sum (0 :: Int), [k])
+                        let (Sum _nI, Sum _nD, _invs) =
+                                mconcat result
+                        t2 <- clock
+                        pure (t2 - t1)
+                pure
+                    $ fromIntegral totalNs
+                        / (1000 * fromIntegral (length measureUtxos))
+
+{- | Run many separate transactions, measuring per-UTxO cost over time.
+Each transaction inserts one batch, like production forwardTip.
+-}
+runRepeatedTransactionsBench
+    :: Int
+    -- ^ Number of rounds (each round = all UTxOs)
+    -> [(ByteString, ByteString)]
+    -> IO ()
+runRepeatedTransactionsBench rounds utxos =
+    withSystemTempDirectory "csmt-bench" $ \tmpDir ->
+        withDBCF
+            tmpDir
+            rocksConfig
+            [ ("kv", rocksConfig)
+            , ("csmt", rocksConfig)
+            , ("rollbacks", rocksConfig)
+            , ("config", rocksConfig)
+            , ("journal", rocksConfig)
+            ]
+            $ \db -> do
+                let CSMTOps{csmtInsert} =
+                        kvOnlyCSMTOps (view strict)
+                    clock
+                        :: Transaction
+                            IO
+                            cf
+                            cols
+                            op
+                            Word64
+                    clock = lift (lift (liftIO getMonotonicTimeNSec))
+                runner@RunTransaction{transact} <-
+                    newRunRocksDBTransaction
+                        db
+                        benchPrisms
+                setup
+                    nullTracer
+                    runner
+                    benchArmageddonParams
+                let nUtxos = length utxos
+                forM_ [1 .. rounds] $ \r -> do
+                    -- Each round: one transaction per UTxO batch
+                    -- (simulates one block = one transaction)
+                    let prefix =
+                            LBS.fromStrict
+                                $ B.pack
+                                    [ fromIntegral (r `div` 256)
+                                    , fromIntegral (r `mod` 256)
+                                    ]
+                    ns <- transact $ do
+                        t1 <- clock
+                        forM_ utxos $ \(k, v) ->
+                            csmtInsert (prefix <> k) v
+                        t2 <- clock
+                        pure (t2 - t1)
+                    let usPerUtxo =
+                            fromIntegral ns
+                                / (1000 * fromIntegral nUtxos)
+                                :: Double
+                    when (r `mod` 50 == 0)
+                        $ putStrLn
+                        $ "  round "
+                            ++ show r
+                            ++ " ("
+                            ++ show (r * nUtxos)
+                            ++ " total entries): "
+                            ++ show (round usPerUtxo :: Int)
+                            ++ " μs/UTxO"
+
+-- | Split list into chunks of given size
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf n xs =
+    let (h, t) = splitAt n xs
+    in  h : chunksOf n t
+
+{- | Benchmark that mirrors the production forwardTip pattern exactly:
+all UTxOs in one transaction, using Operation wrapper, with
+clock/forM/clock structure matching the production do-block.
+-}
+runForwardTipStyleBench
+    :: [(ByteString, ByteString)]
+    -> IO ()
+runForwardTipStyleBench utxos =
+    withSystemTempDirectory "csmt-bench" $ \tmpDir ->
+        withDBCF
+            tmpDir
+            rocksConfig
+            [ ("kv", rocksConfig)
+            , ("csmt", rocksConfig)
+            , ("rollbacks", rocksConfig)
+            , ("config", rocksConfig)
+            , ("journal", rocksConfig)
+            ]
+            $ \db -> do
+                let CSMTOps{csmtInsert, csmtDelete} =
+                        kvOnlyCSMTOps (view strict)
+                    clock
+                        :: Transaction
+                            IO
+                            cf
+                            cols
+                            op
+                            Word64
+                    clock = lift (lift (liftIO getMonotonicTimeNSec))
+                    -- Convert to Operations like production does
+                    -- Duplicate to get ~2040 like production big blocks
+                    doubled =
+                        utxos
+                            ++ [(LBS.fromStrict (B.singleton 0xFF) <> k, v) | (k, v) <- utxos]
+                    ops :: [Operation ByteString ByteString]
+                    ops = [Insert k v | (k, v) <- doubled]
+                runner@RunTransaction{transact} <-
+                    newRunRocksDBTransaction
+                        db
+                        benchPrisms
+                setup
+                    nullTracer
+                    runner
+                    benchArmageddonParams
+                -- Run multiple rounds to see if it's stable
+                forM_ [1 :: Int .. 10] $ \rnd -> do
+                    t0 <- getMonotonicTimeNSec
+                    -- This mirrors production goKVOnly exactly:
+                    _stored <- transact $ do
+                        tCsmt0 <- clock
+                        let nTotal = length ops
+                        forM_ (zip [0 :: Int ..] ops) $ \(i, op) -> do
+                            t <-
+                                if i < 10 || i `mod` 100 == 0 || i >= nTotal - 10
+                                    then Just <$> clock
+                                    else pure Nothing
+                            case op of
+                                Insert k v ->
+                                    csmtInsert k v
+                                Delete k ->
+                                    void $ csmtDelete k
+                            case t of
+                                Just t' -> do
+                                    t'' <- clock
+                                    lift
+                                        ( lift
+                                            ( liftIO
+                                                ( putStrLn
+                                                    $ "    op["
+                                                        ++ show i
+                                                        ++ "]: "
+                                                        ++ show (fromIntegral (t'' - t') / 1000 :: Double)
+                                                        ++ " μs"
+                                                )
+                                            )
+                                        )
+                                Nothing -> pure ()
+                        tCsmt1 <- clock
+                        let nOps = length ops
+                            usPerOp =
+                                fromIntegral (tCsmt1 - tCsmt0)
+                                    / (1000 * fromIntegral nOps)
+                                    :: Double
+                        _ <- clock
+                        pure (nOps, usPerOp)
+                    t1 <- getMonotonicTimeNSec
+                    let (nOps, usPerOp) = _stored
+                        totalMs =
+                            fromIntegral (t1 - t0) / 1e6 :: Double
+                    putStrLn
+                        $ "  round "
+                            ++ show rnd
+                            ++ ": "
+                            ++ show nOps
+                            ++ " ops, "
+                            ++ show (Prelude.round usPerOp :: Int)
+                            ++ " μs/UTxO internal, "
+                            ++ show (Prelude.round totalMs :: Int)
+                            ++ " ms total"
+
 -- | Armageddon params for setup
 benchArmageddonParams :: ArmageddonParams Hash
 benchArmageddonParams =
@@ -130,3 +543,113 @@ benchArmageddonParams =
         { noHash = mkHash ""
         , armageddonBatchSize = 1000
         }
+
+{- | Stress benchmark: feeds thousands of synthetic blocks through
+the full Update state machine (same pipeline as production), without
+network. Measures per-block and per-UTxO timing to reproduce the
+production slowdown.
+-}
+runStressBench
+    :: Int
+    -- ^ Number of blocks to simulate
+    -> [(ByteString, ByteString)]
+    -- ^ Golden UTxOs (used as template for each block)
+    -> IO ()
+runStressBench nBlocks utxos =
+    withSystemTempDirectory "csmt-stress" $ \tmpDir ->
+        withDBCF
+            tmpDir
+            rocksConfig
+            [ ("kv", rocksConfig)
+            , ("csmt", rocksConfig)
+            , ("rollbacks", rocksConfig)
+            , ("config", rocksConfig)
+            , ("journal", rocksConfig)
+            ]
+            $ \db -> do
+                let csmtOps = kvOnlyCSMTOps (view strict)
+                    benchOps =
+                        BenchOps
+                            { doQueryTip = False
+                            , doCsmt = True
+                            , doRollback = False
+                            }
+                runner <- newRunRocksDBTransaction db benchPrisms
+                (update0, _cps) <-
+                    createUpdateState
+                        (nullTracer :: Tracer IO (UpdateTrace () Hash))
+                        benchOps
+                        csmtOps
+                        (const $ mkHash "")
+                        (\_ _ -> pure ())
+                        benchArmageddonParams
+                        runner
+                let nOps = length utxos
+                    -- Generate fixed-size 34-byte keys (like real UTxO refs:
+                    -- 32-byte tx hash + 2-byte index). We encode block+index
+                    -- into 34 zero-padded bytes so DB key size matches production.
+                    mkKey :: Int -> Int -> ByteString
+                    mkKey blk idx =
+                        let w32 n =
+                                B.pack
+                                    [ fromIntegral ((n `shiftR` 24) .&. 0xFF)
+                                    , fromIntegral ((n `shiftR` 16) .&. 0xFF)
+                                    , fromIntegral ((n `shiftR` 8) .&. 0xFF)
+                                    , fromIntegral (n .&. 0xFF)
+                                    ]
+                        in  LBS.fromStrict
+                                $ w32 blk
+                                    <> w32 idx
+                                    <> B.replicate 26 0
+                    -- Each block inserts nOps new keys and deletes nOps/2
+                    -- keys from block (blk - 3). Since block (blk - 3)
+                    -- inserted nOps keys and we only delete half, the
+                    -- other half remains — so the DB grows by nOps/2 per
+                    -- block. All deletes hit keys that exist in the DB.
+                    mkBlockOps :: Int -> [Operation ByteString ByteString]
+                    mkBlockOps blk =
+                        let inserts =
+                                [ Insert (mkKey blk idx) v
+                                | (idx, (_k, v)) <- zip [0 ..] utxos
+                                ]
+                            deletes
+                                | blk > 3 =
+                                    [ Delete (mkKey (blk - 3) idx)
+                                    | idx <- [0 .. nOps `div` 2 - 1]
+                                    ]
+                                | otherwise = []
+                        in  deletes ++ inserts
+                putStrLn
+                    $ "Stress: "
+                        ++ show nBlocks
+                        ++ " blocks × ~"
+                        ++ show nOps
+                        ++ " ins + "
+                        ++ show (nOps `div` 2)
+                        ++ " del/block (unique keys)"
+                -- Feed blocks through the Update state machine
+                let go !i !update
+                        | i > nBlocks = pure ()
+                        | otherwise = do
+                            let !blockOps = mkBlockOps i
+                                !nBlockOps = length blockOps
+                            t0 <- getMonotonicTimeNSec
+                            update' <-
+                                forwardTipApply update () () blockOps
+                            t1 <- getMonotonicTimeNSec
+                            let totalUs =
+                                    fromIntegral (t1 - t0)
+                                        / 1000
+                                        :: Double
+                                usPerOp = totalUs / fromIntegral nBlockOps
+                            when (i <= 10 || i `mod` 100 == 0)
+                                $ putStrLn
+                                $ "  block "
+                                    ++ show i
+                                    ++ ": "
+                                    ++ show (round totalUs :: Int)
+                                    ++ " μs total, "
+                                    ++ show (round usPerOp :: Int)
+                                    ++ " μs/UTxO"
+                            go (i + 1) update'
+                go (1 :: Int) update0

--- a/bench/main.hs
+++ b/bench/main.hs
@@ -1,6 +1,17 @@
 module Main (main) where
 
-import Bench.CSMT (loadGoldenUtxos, runInsertBench)
+import Bench.CSMT
+    ( loadGoldenUtxos
+    , runForwardTipStyleBench
+    , runInsertBench
+    , runKVOnlyInsertBench
+    , runKVOnlyInternalTimingBench
+    , runKVOnlyPrePopulatedBench
+    , runKVOnlySmallBatchBench
+    , runPureSerializationBench
+    , runRepeatedTransactionsBench
+    , runStressBench
+    )
 import Criterion.Main
     ( bench
     , bgroup
@@ -8,15 +19,121 @@ import Criterion.Main
     , env
     , nfIO
     )
+import System.Environment (getArgs)
 
 main :: IO ()
-main =
+main = do
+    args <- getArgs
+    case args of
+        ["--internal-only"] -> internalOnly
+        ["--batch-scaling"] -> batchScaling
+        ["--repeated-txns"] -> repeatedTxns
+        ["--forward-tip"] -> forwardTipStyle
+        ["--stress"] -> stressBench 2000
+        ["--stress", n] -> stressBench (read n)
+        _ -> criterionMain
+
+internalOnly :: IO ()
+internalOnly = do
+    putStrLn "Loading golden UTxOs..."
+    utxos <- loadGoldenUtxos
+    putStrLn $ "Loaded " ++ show (length utxos) ++ " UTxOs"
+    putStrLn ""
+    putStrLn "=== Pre-populated DB scaling ==="
+    mapM_
+        ( \(rounds, label) -> do
+            putStrLn $ "--- " ++ label ++ " ---"
+            putStrLn $ "  Pre-populating " ++ label ++ "..."
+            us <- runKVOnlyPrePopulatedBench rounds 8 utxos
+            putStrLn
+                $ "  "
+                    ++ label
+                    ++ " 8/txn: "
+                    ++ show (round us :: Int)
+                    ++ " μs/UTxO"
+            putStrLn ""
+        )
+        [ (0, "empty DB")
+        , (100, "100k entries")
+        , (500, "500k entries")
+        , (1000, "1M entries")
+        , (2000, "2M entries")
+        , (3000, "3M entries")
+        ]
+
+{- | Run many separate transactions (like production) to see
+if per-UTxO cost increases over time
+-}
+repeatedTxns :: IO ()
+repeatedTxns = do
+    putStrLn "Loading golden UTxOs..."
+    utxos <- loadGoldenUtxos
+    putStrLn $ "Loaded " ++ show (length utxos) ++ " UTxOs"
+    putStrLn ""
+    putStrLn "=== Repeated separate transactions ==="
+    runRepeatedTransactionsBench 500 utxos
+
+-- | Test with the exact same code structure as production forwardTip
+forwardTipStyle :: IO ()
+forwardTipStyle = do
+    putStrLn "Loading golden UTxOs..."
+    utxos <- loadGoldenUtxos
+    putStrLn $ "Loaded " ++ show (length utxos) ++ " UTxOs"
+    putStrLn ""
+    putStrLn
+        "=== Forward-tip style (all ops in one txn, Operation wrapper) ==="
+    runForwardTipStyleBench utxos
+
+batchScaling :: IO ()
+batchScaling = do
+    putStrLn "Loading golden UTxOs..."
+    utxos <- loadGoldenUtxos
+    let n = length utxos
+    putStrLn $ "Loaded " ++ show n ++ " UTxOs"
+    putStrLn ""
+    putStrLn "=== Batch size scaling (internal timing) ==="
+    mapM_
+        ( \batchSize -> do
+            us <- runKVOnlyInternalTimingBench batchSize utxos
+            putStrLn
+                $ "  batch="
+                    ++ show batchSize
+                    ++ ": "
+                    ++ show (round us :: Int)
+                    ++ " μs/UTxO"
+        )
+        [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, n]
+
+-- | Stress benchmark: full Update state machine, thousands of blocks
+stressBench :: Int -> IO ()
+stressBench nBlocks = do
+    putStrLn "Loading golden UTxOs..."
+    utxos <- loadGoldenUtxos
+    putStrLn $ "Loaded " ++ show (length utxos) ++ " UTxOs"
+    putStrLn ""
+    putStrLn "=== Stress benchmark (full Update state machine) ==="
+    runStressBench nBlocks utxos
+
+criterionMain :: IO ()
+criterionMain =
     defaultMain
         [ env loadGoldenUtxos $ \utxos ->
             bgroup
                 "CSMT"
-                [ bench ("insert " ++ show (length utxos) ++ " UTxOs")
+                [ bench ("full insert " ++ show (length utxos) ++ " UTxOs")
                     $ nfIO
                     $ runInsertBench utxos
+                , bench ("kvonly 1-txn " ++ show (length utxos) ++ " UTxOs")
+                    $ nfIO
+                    $ runKVOnlyInsertBench utxos
+                , bench ("kvonly 8/txn " ++ show (length utxos) ++ " UTxOs")
+                    $ nfIO
+                    $ runKVOnlySmallBatchBench 8 utxos
+                , bench ("kvonly 1/txn " ++ show (length utxos) ++ " UTxOs")
+                    $ nfIO
+                    $ runKVOnlySmallBatchBench 1 utxos
+                , bench ("pure serialization " ++ show (length utxos) ++ " UTxOs")
+                    $ nfIO
+                    $ runPureSerializationBench utxos
                 ]
         ]

--- a/cabal.project
+++ b/cabal.project
@@ -44,8 +44,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/contra-tracer-contrib
-  tag: 9c2555a5e6d72fdd55eb1e13cff812d72ea41913
-  --sha256: 03s9q9arz8km5hc08zsv7zxjzigy34rqf521p94xm2n4vmly2i7f
+  tag: 4f0c611e61b866905455a5d5469dea62afc55c3a
+  --sha256: 1k5c9kr1pw4c6qswssbjvma0ki7d31n3w275v6w9kkp23wwdh2g2
 
 source-repository-package
   type: git
@@ -55,3 +55,4 @@ source-repository-package
 
 -- Enable iohk flag for contra-tracer-contrib to use CHaP's simple API
 constraints: contra-tracer-contrib +iohk
+

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -472,7 +472,9 @@ benchmark bench
     , contra-tracer
     , criterion
     , lens
+    , mtl
     , mts:csmt
     , rocksdb-haskell-jprupp
+    , rocksdb-kv-transactions:kv-transactions
     , serialise
     , temporary

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -126,6 +126,30 @@
                     "format": "double",
                     "type": "number"
                 },
+                "avgBlockDecodeDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "avgCSMTDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "avgFinalityDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "avgRollbackDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "avgTotalBlockDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "avgTransactionDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
                 "baseCheckpoint": {
                     "type": "string"
                 },
@@ -147,6 +171,47 @@
                     "maximum": 1.8446744073709551615e19,
                     "minimum": 0,
                     "type": "integer"
+                },
+                "cumulativeBlockDecodeDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "cumulativeBlocks": {
+                    "maximum": 9223372036854775807,
+                    "minimum": -9223372036854775808,
+                    "type": "integer"
+                },
+                "cumulativeCSMTDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "cumulativeFinalityDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "cumulativeInternalCsmtOps": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "cumulativeInternalQueryTip": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "cumulativeInternalRollbackStore": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "cumulativeRollbackDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "cumulativeTotalBlockDuration": {
+                    "format": "double",
+                    "type": "number"
+                },
+                "cumulativeTransactionDuration": {
+                    "format": "double",
+                    "type": "number"
                 },
                 "currentEra": {
                     "type": "string"
@@ -199,7 +264,23 @@
                 "extractionProgress",
                 "headerSyncProgress",
                 "downloadedBytes",
-                "countingProgress"
+                "avgCSMTDuration",
+                "avgRollbackDuration",
+                "avgFinalityDuration",
+                "avgBlockDecodeDuration",
+                "avgTransactionDuration",
+                "avgTotalBlockDuration",
+                "countingProgress",
+                "cumulativeBlocks",
+                "cumulativeBlockDecodeDuration",
+                "cumulativeTransactionDuration",
+                "cumulativeCSMTDuration",
+                "cumulativeRollbackDuration",
+                "cumulativeFinalityDuration",
+                "cumulativeTotalBlockDuration",
+                "cumulativeInternalQueryTip",
+                "cumulativeInternalCsmtOps",
+                "cumulativeInternalRollbackStore"
             ],
             "type": "object"
         },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,6 +67,39 @@ This will:
 4. Start chain sync from the snapshot slot
 
 
+### Bootstrap from Genesis
+
+To sync from the very beginning of the chain without Mithril, use the genesis
+bootstrap option. This pre-populates the database with the initial UTxO set
+from the genesis files so that chain sync can process all blocks correctly
+(including early blocks that spend genesis UTxOs).
+
+```bash
+nix run github:paolino/cardano-utxo-csmt -- \
+  --network preprod \
+  --socket-path /path/to/node.socket \
+  --genesis-file /path/to/shelley-genesis.json \
+  --byron-genesis-file /path/to/byron-genesis.json \
+  --db-path /tmp/csmt-db \
+  --api-port 8080
+```
+
+This will:
+
+1. Read initial UTxOs from both Byron and Shelley genesis files
+2. Insert them into the CSMT database
+3. Start chain sync from Origin
+
+!!! warning
+    Starting without `--genesis-file` and `--byron-genesis-file` will crash
+    on the first block that spends a genesis UTxO, because the UTxO won't
+    exist in the database yet. Always provide genesis files when syncing
+    from Origin without Mithril.
+
+The genesis files are part of the node configuration. For a local NixOS node
+they are typically found alongside the node config (e.g.
+`/path/to/node/configs/shelley-genesis.json`).
+
 ## Configuration Options
 
 | Option | Description |
@@ -74,9 +107,12 @@ This will:
 | `--network` | Network: `mainnet`, `preprod`, `preview` (default: mainnet) |
 | `--node-name` | Override peer node hostname |
 | `--node-port` | Override peer node port |
+| `--socket-path` | Node-to-Client Unix socket path |
 | `--db-path` | RocksDB database path (required) |
 | `--api-port` | HTTP API port for REST endpoints |
 | `--api-docs-port` | HTTP port for Swagger UI documentation |
+| `--genesis-file` | Path to shelley-genesis.json for genesis bootstrap |
+| `--byron-genesis-file` | Path to byron-genesis.json for genesis bootstrap |
 | `--mithril-bootstrap` | Bootstrap from Mithril snapshot |
 | `--mithril-ancillary-verification-key` | Ed25519 key for ancillary verification |
 | `--mithril-genesis-verification-key` | Genesis key for mithril-client CLI |

--- a/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
+++ b/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
@@ -17,6 +17,9 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
     , mkCSMTOps
     )
+import Cardano.UTxOCSMT.Application.Database.Implementation.Update
+    ( allOps
+    )
 import Cardano.UTxOCSMT.Application.Database.RocksDB
     ( createUpdateState
     , newRunRocksDBTransaction
@@ -125,6 +128,7 @@ spec = describe "Genesis chain sync" $ do
                                     (state, slots) <-
                                         createUpdateState
                                             nullTracer
+                                            allOps
                                             ops
                                             slotHash
                                             (\_ _ -> pure ())

--- a/flake.nix
+++ b/flake.nix
@@ -56,12 +56,22 @@
               inherit project;
             };
 
+            docker-image-profiled = pkgs.dockerTools.buildImage {
+              name = "ghcr.io/paolino/cardano-utxo-csmt/cardano-utxo-csmt";
+              tag = "${version}-profiled";
+              config = { EntryPoint = [ "cardano-utxo" ]; };
+              copyToRoot = pkgs.buildEnv {
+                name = "image-root";
+                paths = [ project.packages.cardano-utxo-profiled ];
+              };
+            };
+
           in rec {
             packages = {
               inherit (project.packages)
                 bench unit-tests integration-tests e2e-tests cardano-utxo
-                cardano-utxo-swagger;
-              inherit docker-image;
+                cardano-utxo-swagger cardano-utxo-profiled bench-profiled;
+              inherit docker-image docker-image-profiled;
               default = packages.cardano-utxo;
             };
             inherit (project) devShells;

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
@@ -3,9 +3,15 @@ module Cardano.UTxOCSMT.Application.Database.Implementation.Update
     , mkSplitUpdate
     , newSplitState
 
+      -- * Bench mode
+    , BenchOps (..)
+    , allOps
+    , noOps
+
       -- * Tracing
     , UpdateTrace (..)
     , renderUpdateTrace
+    , measureUpdateDurations
 
       -- * Low level operations, exposed for testing
     , forwardTip
@@ -48,7 +54,10 @@ import Data.Function (fix)
 import Data.List.SampleFibonacci
     ( sampleAtFibonacciIntervals
     )
+
 import Data.Monoid (Sum (..))
+
+import Data.Tracer.Measure (Timing (..), measureDuration)
 import Data.Tracer.TraceWith
     ( contra
     , trace
@@ -72,6 +81,24 @@ import MTS.Rollbacks.Store qualified as Store
 import MTS.Rollbacks.Types qualified as RP
 import Ouroboros.Network.Point (WithOrigin (..))
 
+-- | Controls which DB operations run inside 'forwardTip'.
+data BenchOps = BenchOps
+    { doQueryTip :: Bool
+    -- ^ Read tip from rollback points
+    , doCsmt :: Bool
+    -- ^ Run CSMT insert/delete operations
+    , doRollback :: Bool
+    -- ^ Store rollback point (includes root hash read)
+    }
+
+-- | All operations enabled (normal mode).
+allOps :: BenchOps
+allOps = BenchOps True True True
+
+-- | No operations (baseline: transaction overhead only).
+noOps :: BenchOps
+noOps = BenchOps False False False
+
 -- | Query the current tip directly from rollback points.
 queryTip
     :: MonadFail m
@@ -82,31 +109,185 @@ queryTip = do
         Nothing -> lift $ fail "No tip in rollback points"
         Just t -> pure t
 
+-- | Trace events for database update operations.
 data UpdateTrace slot hash
     = UpdateArmageddon ArmageddonTrace
-    | UpdateForwardTip slot Int Int (Maybe hash)
+    | -- | CSMT ops begin (inside transaction)
+      UpdateCSMTBegin slot
+    | -- | CSMT ops done (before rollback point)
+      UpdateCSMTDone slot Int Int
+    | -- | CSMT ops with measured duration (seconds)
+      UpdateCSMTMeasured slot Int Int Double
+    | -- | Rollback point begin
+      UpdateRollbackBegin slot
+    | -- | Rollback point stored (after CSMT ops)
+      UpdateForwardTip slot Int Int (Maybe hash)
+    | -- | Rollback point with measured duration (seconds)
+      UpdateRollbackMeasured
+        slot
+        Int
+        Int
+        (Maybe hash)
+        Double
     | UpdateNewState [slot]
     | UpdateJournalReplay
+    | -- | Finality begin (before pruning)
+      UpdateFinalityBegin slot
+    | -- | Finality pruning complete
+      UpdateFinalityDone slot Int
+    | -- | Finality with measured duration (seconds)
+      UpdateFinalityMeasured slot Int Double
+    | -- | Per-UTxO timing: inserts then deletes (μs per operation)
+      UpdatePerUtxoTiming [Double] [Double]
+    | -- | Clock overhead: consecutive clock reads (μs)
+      UpdateClockOverhead Double
+    | -- | Loop overhead: clock-only iterations (μs per iter)
+      UpdateLoopOverhead Double
+    | -- | Raw Map.insert timing outside Transaction monad (μs per iter)
+      UpdateRawMapInsert Double
+    | -- | Sub-operation breakdown: kvInsert μs, serialize μs, journalInsert μs
+      UpdateSubOps Double Double Double
+    | -- | Full transact begin (before transact call)
+      UpdateTransactBegin slot
+    | -- | Full transact done (after transact returns)
+      UpdateTransactDone slot
+    | -- | Full transact with measured duration (seconds)
+      UpdateTransactMeasured slot Double
     deriving (Show)
 
-renderUpdateTrace :: Show slot => UpdateTrace slot hash -> String
-renderUpdateTrace (UpdateArmageddon t) = renderArmageddonTrace t
-renderUpdateTrace (UpdateForwardTip slot nInsert nDelete _merkleRoot) =
-    "Forward tip at "
+-- | Render an 'UpdateTrace' to a human-readable string.
+renderUpdateTrace
+    :: Show slot => UpdateTrace slot hash -> String
+renderUpdateTrace (UpdateArmageddon t) =
+    renderArmageddonTrace t
+renderUpdateTrace (UpdateCSMTBegin slot) =
+    "CSMT begin at " ++ show slot
+renderUpdateTrace (UpdateCSMTDone slot nInsert nDelete) =
+    "CSMT done at "
         ++ show slot
         ++ ": "
         ++ show nInsert
         ++ " inserts, "
         ++ show nDelete
         ++ " deletes"
+renderUpdateTrace
+    (UpdateCSMTMeasured slot nInsert nDelete secs) =
+        "CSMT at "
+            ++ show slot
+            ++ ": "
+            ++ show nInsert
+            ++ " inserts, "
+            ++ show nDelete
+            ++ " deletes ("
+            ++ show (round (secs * 1e6) :: Int)
+            ++ "μs)"
+renderUpdateTrace (UpdateRollbackBegin slot) =
+    "Rollback begin at " ++ show slot
+renderUpdateTrace (UpdateForwardTip slot nInsert nDelete _) =
+    "Rollback point at "
+        ++ show slot
+        ++ ": "
+        ++ show nInsert
+        ++ " inserts, "
+        ++ show nDelete
+        ++ " deletes"
+renderUpdateTrace
+    ( UpdateRollbackMeasured
+            slot
+            nInsert
+            nDelete
+            _
+            secs
+        ) =
+        "Rollback point at "
+            ++ show slot
+            ++ ": "
+            ++ show nInsert
+            ++ " inserts, "
+            ++ show nDelete
+            ++ " deletes ("
+            ++ show (round (secs * 1e6) :: Int)
+            ++ "μs)"
 renderUpdateTrace (UpdateNewState slots) =
-    "New update state with rollback points at: " ++ show slots
+    "New update state with rollback points at: "
+        ++ show slots
 renderUpdateTrace UpdateJournalReplay =
     "Replaying journal to build CSMT tree"
+renderUpdateTrace (UpdateFinalityBegin slot) =
+    "Finality begin at " ++ show slot
+renderUpdateTrace (UpdateFinalityDone slot pruned) =
+    "Finality done at "
+        ++ show slot
+        ++ ": pruned "
+        ++ show pruned
+        ++ " rollback points"
+renderUpdateTrace (UpdateFinalityMeasured slot pruned secs) =
+    "Finality at "
+        ++ show slot
+        ++ ": pruned "
+        ++ show pruned
+        ++ " rollback points ("
+        ++ show (round (secs * 1e6) :: Int)
+        ++ "μs)"
+renderUpdateTrace (UpdateClockOverhead us) =
+    "ClockOverhead: "
+        ++ show (round us :: Int)
+        ++ "μs"
+renderUpdateTrace (UpdateLoopOverhead us) =
+    "LoopOverhead: "
+        ++ show (round us :: Int)
+        ++ "μs/iter"
+renderUpdateTrace (UpdateRawMapInsert us) =
+    "RawMapInsert: "
+        ++ show (round us :: Int)
+        ++ "μs/iter"
+renderUpdateTrace (UpdateSubOps kvUs serUs jrnUs) =
+    "SubOps: kv="
+        ++ show (round kvUs :: Int)
+        ++ "μs ser="
+        ++ show (round serUs :: Int)
+        ++ "μs jrn="
+        ++ show (round jrnUs :: Int)
+        ++ "μs"
+renderUpdateTrace (UpdatePerUtxoTiming inserts deletes) =
+    let showStats label ts = case ts of
+            [] -> label ++ ": none"
+            _ ->
+                label
+                    ++ ": n="
+                    ++ show (length ts)
+                    ++ " min="
+                    ++ show (round (minimum ts) :: Int)
+                    ++ "μs max="
+                    ++ show (round (maximum ts) :: Int)
+                    ++ "μs mean="
+                    ++ show
+                        ( round (sum ts / fromIntegral (length ts))
+                            :: Int
+                        )
+                    ++ "μs"
+    in  showStats "Ins" inserts
+            ++ " | "
+            ++ showStats "Del" deletes
+renderUpdateTrace (UpdateTransactBegin slot) =
+    "Transact begin at " ++ show slot
+renderUpdateTrace (UpdateTransactDone slot) =
+    "Transact done at " ++ show slot
+renderUpdateTrace (UpdateTransactMeasured slot secs) =
+    "Transact at "
+        ++ show slot
+        ++ " ("
+        ++ show (round (secs * 1e6) :: Int)
+        ++ "μs)"
 
 newState
-    :: (Ord key, Ord slot, Show slot, MonadFail m)
+    :: ( Ord key
+       , Ord slot
+       , Show slot
+       , MonadFail m
+       )
     => Tracer m (UpdateTrace slot hash)
+    -> BenchOps
     -> CSMTOps
         (Transaction m cf (Columns slot hash key value) op)
         key
@@ -120,6 +301,7 @@ newState
     -> m (Update m slot key value, [slot])
 newState
     TraceWith{tracer, trace}
+    benchOps
     ops
     slotHash
     onForward
@@ -135,25 +317,35 @@ newState
                     Store.countPoints RollbackPoints
                 pure (cps, rollbackCount)
         trace $ UpdateNewState cps
-        pure
-            $ (,cps)
-            $ mkUpdate
-                tracer
-                ops
-                slotHash
-                onForward
-                armageddonParams
-                runTransaction
-                rollbackCount
+        let update =
+                mkUpdate
+                    tracer
+                    benchOps
+                    ops
+                    slotHash
+                    onForward
+                    armageddonParams
+                    runTransaction
+                    rollbackCount
+        pure (update, cps)
 
 {- | Initialize split-mode state.
 
-If the journal is non-empty, start in KVOnly mode (will replay
-on first tip touch). If empty, start in Full mode directly.
+Start in KVOnly mode unless the journal is empty AND the database
+already has rollback points (meaning a previous KVOnly phase
+completed and replayed successfully). A fresh empty database
+starts in KVOnly mode.
 -}
 newSplitState
-    :: (Ord key, Ord slot, Show slot, MonadFail m)
+    :: ( Ord key
+       , Ord slot
+       , Show slot
+       , MonadFail m
+       )
     => Tracer m (UpdateTrace slot hash)
+    -> BenchOps
+    -> Bool
+    -- ^ Is this a fresh (genesis) database?
     -> CSMTOps
         (Transaction m cf (Columns slot hash key value) op)
         key
@@ -177,6 +369,8 @@ newSplitState
     -> m (Update m slot key value, [slot])
 newSplitState
     tw@TraceWith{tracer, trace}
+    benchOps
+    isGenesis
     kvOps
     fullOps
     replay
@@ -196,39 +390,42 @@ newSplitState
                 empty <- journalEmpty
                 pure (cps, rollbackCount, empty)
         trace $ UpdateNewState cps
-        if empty
-            then
-                pure
-                    $ (,cps)
-                    $ mkUpdate
-                        tracer
-                        fullOps
-                        slotHash
-                        onForward
-                        armageddonParams
-                        runTransaction
-                        rollbackCount
-            else
-                pure
-                    $ (,cps)
-                    $ mkSplitUpdate
-                        tw
-                        kvOps
-                        fullOps
-                        replay
-                        isAtTip
-                        slotHash
-                        onForward
-                        armageddonParams
-                        runTransaction
-                        rollbackCount
+        let update =
+                if empty && not isGenesis
+                    then
+                        mkUpdate
+                            tracer
+                            benchOps
+                            fullOps
+                            slotHash
+                            onForward
+                            armageddonParams
+                            runTransaction
+                            rollbackCount
+                    else
+                        mkSplitUpdate
+                            tw
+                            benchOps
+                            kvOps
+                            fullOps
+                            replay
+                            isAtTip
+                            slotHash
+                            onForward
+                            armageddonParams
+                            runTransaction
+                            rollbackCount
+        pure (update, cps)
 
-{- | Apply forward tip .
-We compose csmt transactions for each operation with an updateRollbackPoint one
--}
+-- | Apply forward tip.
 forwardTip
-    :: (Ord key, Ord slot, Show slot, MonadFail m)
+    :: ( Ord key
+       , Ord slot
+       , Show slot
+       , MonadFail m
+       )
     => Tracer m (UpdateTrace slot hash)
+    -> BenchOps
     -> CSMTOps
         (Transaction m cf (Columns slot hash key value) op)
         key
@@ -249,52 +446,73 @@ forwardTip
         Bool
 forwardTip
     TraceWith{trace}
+    BenchOps{doQueryTip, doCsmt, doRollback}
     CSMTOps{csmtInsert, csmtDelete, csmtRootHash}
     hash
     count
     slot
     ops = do
-        tip <- queryTip
+        let io = lift . lift
+        tip <-
+            if doQueryTip
+                then queryTip
+                else pure Origin
         if At slot > tip
             && (not (null ops) || count < 2)
             then do
+                io . trace $ UpdateCSMTBegin slot
                 result <-
-                    forM (zip [0 :: Int ..] ops) $ \case
-                        (_, Insert k v) -> do
-                            csmtInsert k v
-                            pure (Sum 1, Sum 0, [Delete k])
-                        (i, Delete k) -> do
-                            mx <- query KVCol k
-                            csmtDelete k
-                            case mx of
-                                Nothing ->
-                                    error
-                                        $ "forwardTip: cannot"
-                                            <> " invert Delete"
-                                            <> " at slot "
-                                            <> show slot
-                                            <> " op #"
-                                            <> show i
-                                Just x ->
-                                    pure
-                                        ( Sum 0
-                                        , Sum 1
-                                        , [Insert k x]
-                                        )
+                    if doCsmt
+                        then forM (zip [0 :: Int ..] ops)
+                            $ \case
+                                (_, Insert k v) -> do
+                                    csmtInsert k v
+                                    pure (Sum 1, Sum 0, [Delete k])
+                                (i, Delete k) -> do
+                                    mx <- query KVCol k
+                                    csmtDelete k
+                                    case mx of
+                                        Nothing ->
+                                            error
+                                                $ "forwardTip: cannot"
+                                                    <> " invert Delete"
+                                                    <> " at slot "
+                                                    <> show slot
+                                                    <> " op #"
+                                                    <> show i
+                                        Just x ->
+                                            pure
+                                                ( Sum 0
+                                                , Sum 1
+                                                , [Insert k x]
+                                                )
+                        else pure []
                 let (Sum nInserts, Sum nDeletes, invs) =
                         mconcat result
-                merkleRoot <-
-                    updateRollbackPoint
-                        csmtRootHash
-                        hash
-                        slot
-                        $ reverse invs
-                lift . lift . trace
-                    $ UpdateForwardTip
-                        slot
-                        nInserts
-                        nDeletes
-                        merkleRoot
+                io . trace
+                    $ UpdateCSMTDone slot nInserts nDeletes
+                if doRollback
+                    then do
+                        io . trace $ UpdateRollbackBegin slot
+                        merkleRoot <-
+                            updateRollbackPoint
+                                csmtRootHash
+                                hash
+                                slot
+                                $ reverse invs
+                        io . trace
+                            $ UpdateForwardTip
+                                slot
+                                nInserts
+                                nDeletes
+                                merkleRoot
+                    else
+                        io . trace
+                            $ UpdateForwardTip
+                                slot
+                                nInserts
+                                nDeletes
+                                Nothing
                 pure True
             else pure False
 
@@ -350,8 +568,13 @@ rollbackRollbackPoint CSMTOps{csmtInsert, csmtDelete} (UTxORollbackPoint _ ops _
 rollback point counter through each continuation.
 -}
 mkUpdate
-    :: (Ord key, Ord slot, Show slot, MonadFail m)
+    :: ( Ord key
+       , Ord slot
+       , Show slot
+       , MonadFail m
+       )
     => Tracer m (UpdateTrace slot hash)
+    -> BenchOps
     -> CSMTOps
         (Transaction m cf (Columns slot hash key value) op)
         key
@@ -368,33 +591,40 @@ mkUpdate
     -- ^ Initial rollback point count
     -> Update m slot key value
 mkUpdate
-    TraceWith{tracer, contra}
+    tw@TraceWith{contra, trace}
+    benchOps
     ops
     slotHash
     onForward
     armageddonParams
     runTransaction@RunTransaction{transact} =
-        go
+        go (0 :: Int)
       where
-        go count =
+        go sinceLastPrune count =
             Update
                 { forwardTipApply =
                     \slot chainTip operations -> do
+                        trace $ UpdateTransactBegin slot
                         stored <-
                             transact
                                 $ forwardTip
-                                    tracer
+                                    tw
+                                    benchOps
                                     ops
                                     (slotHash slot)
                                     count
                                     slot
                                     operations
+                        trace $ UpdateTransactDone slot
                         onForward slot chainTip
                         pure
-                            $ go
                             $ if stored
-                                then count + 1
-                                else count
+                                then
+                                    go
+                                        (sinceLastPrune + 1)
+                                        (count + 1)
+                                else
+                                    go sinceLastPrune count
                 , rollbackTipApply = \case
                     At s -> do
                         r <-
@@ -403,34 +633,40 @@ mkUpdate
                                 if At s > tip
                                     then
                                         pure
-                                            $ Store.RollbackSucceeded 0
+                                            $ Store.RollbackSucceeded
+                                                0
                                     else
                                         Store.rollbackTo
                                             RollbackPoints
-                                            (rollbackRollbackPoint ops)
+                                            ( rollbackRollbackPoint
+                                                ops
+                                            )
                                             (At s)
                         case r of
                             Store.RollbackSucceeded deleted ->
                                 pure
                                     $ Syncing
                                     $ go
+                                        0
                                         (count - deleted)
                             Store.RollbackImpossible -> do
                                 armageddonCall
                                 pure
                                     $ Truncating
-                                    $ go 0
+                                    $ go 0 0
                     Origin -> do
                         armageddonCall
-                        pure $ Syncing $ go 0
+                        pure $ Syncing $ go 0 0
                 , forwardFinalityApply = \s -> do
+                    trace $ UpdateFinalityBegin s
                     pruned <-
                         transact
                             $ Store.pruneBelow
                                 RollbackPoints
                                 (At s)
+                    trace $ UpdateFinalityDone s pruned
                     pure
-                        $ go (count - pruned)
+                        $ go 0 (count - pruned)
                 }
         armageddonCall =
             armageddon
@@ -445,8 +681,13 @@ The follower is blocked during replay (forwardTipApply runs
 synchronously), making the transition atomic w.r.t. chain sync.
 -}
 mkSplitUpdate
-    :: (Ord key, Ord slot, Show slot, MonadFail m)
+    :: ( Ord key
+       , Ord slot
+       , Show slot
+       , MonadFail m
+       )
     => Tracer m (UpdateTrace slot hash)
+    -> BenchOps
     -> CSMTOps
         (Transaction m cf (Columns slot hash key value) op)
         key
@@ -472,7 +713,8 @@ mkSplitUpdate
     -- ^ Initial rollback point count
     -> Update m slot key value
 mkSplitUpdate
-    TraceWith{tracer, contra, trace}
+    tw@TraceWith{contra, trace}
+    benchOps
     kvOps
     fullOps
     replay
@@ -481,33 +723,46 @@ mkSplitUpdate
     onForward
     armageddonParams
     runTransaction@RunTransaction{transact} =
-        goKVOnly
+        goKVOnly (0 :: Int)
       where
-        goKVOnly count =
+        goKVOnly sinceLastPrune count =
             Update
                 { forwardTipApply =
                     \slot chainTip operations -> do
+                        trace $ UpdateTransactBegin slot
                         stored <-
                             transact
                                 $ forwardTip
-                                    tracer
+                                    tw
+                                    benchOps
                                     kvOps
                                     (slotHash slot)
                                     count
                                     slot
                                     operations
+                        trace $ UpdateTransactDone slot
                         onForward slot chainTip
-                        let count' =
+                        let (sinceLastPrune', count') =
                                 if stored
-                                    then count + 1
-                                    else count
+                                    then
+                                        ( sinceLastPrune + 1
+                                        , count + 1
+                                        )
+                                    else
+                                        ( sinceLastPrune
+                                        , count
+                                        )
                         if isAtTip slot chainTip
                             then do
                                 trace UpdateJournalReplay
                                 replay
-                                pure $ goFull count'
+                                pure
+                                    $ goFull count'
                             else
-                                pure $ goKVOnly count'
+                                pure
+                                    $ goKVOnly
+                                        sinceLastPrune'
+                                        count'
                 , rollbackTipApply = \case
                     At s -> do
                         r <-
@@ -530,27 +785,35 @@ mkSplitUpdate
                                 pure
                                     $ Syncing
                                     $ goKVOnly
+                                        0
                                         (count - deleted)
                             Store.RollbackImpossible -> do
                                 armageddonCall
                                 pure
                                     $ Truncating
-                                    $ goKVOnly 0
+                                    $ goKVOnly 0 0
                     Origin -> do
                         armageddonCall
-                        pure $ Syncing $ goKVOnly 0
+                        pure
+                            $ Syncing
+                            $ goKVOnly 0 0
                 , forwardFinalityApply = \s -> do
+                    trace $ UpdateFinalityBegin s
                     pruned <-
                         transact
                             $ Store.pruneBelow
                                 RollbackPoints
                                 (At s)
+                    trace $ UpdateFinalityDone s pruned
                     pure
-                        $ goKVOnly (count - pruned)
+                        $ goKVOnly
+                            0
+                            (count - pruned)
                 }
         goFull =
             mkUpdate
-                tracer
+                tw
+                benchOps
                 fullOps
                 slotHash
                 onForward
@@ -582,3 +845,72 @@ newFinality isFinal = do
                         else pure $ case finality of
                             Origin -> Nothing
                             At p -> Just p
+
+{- | Wrap a tracer with duration measurement for
+CSMT ops, rollback point storage, and finality.
+
+'UpdateCSMTBegin' → 'UpdateCSMTDone' becomes
+'UpdateCSMTMeasured'.
+'UpdateCSMTDone' → 'UpdateForwardTip' becomes
+'UpdateRollbackMeasured'.
+'UpdateFinalityBegin' → 'UpdateFinalityDone' becomes
+'UpdateFinalityMeasured'.
+-}
+measureUpdateDurations
+    :: Tracer IO (UpdateTrace slot hash)
+    -> IO (Tracer IO (UpdateTrace slot hash))
+measureUpdateDurations downstream =
+    measureDuration
+        Monotonic
+        selectTransactBegin
+        selectTransactDone
+        composeTransact
+        =<< measureDuration
+            Monotonic
+            selectCSMTBegin
+            selectCSMTDone
+            composeCSMT
+        =<< measureDuration
+            Monotonic
+            selectRollbackBegin
+            selectRollbackEnd
+            composeRollback
+        =<< measureDuration
+            Monotonic
+            selectFinalityBegin
+            selectFinalityEnd
+            composeFinality
+            downstream
+  where
+    selectTransactBegin = \case
+        UpdateTransactBegin s -> Just s
+        _ -> Nothing
+    selectTransactDone = \case
+        UpdateTransactDone s -> Just s
+        _ -> Nothing
+    composeTransact _ =
+        UpdateTransactMeasured
+    selectCSMTBegin = \case
+        UpdateCSMTBegin s -> Just s
+        _ -> Nothing
+    selectCSMTDone = \case
+        UpdateCSMTDone s n d -> Just (s, n, d)
+        _ -> Nothing
+    composeCSMT _ (s, n, d) =
+        UpdateCSMTMeasured s n d
+    selectRollbackBegin = \case
+        UpdateRollbackBegin s -> Just s
+        _ -> Nothing
+    selectRollbackEnd = \case
+        UpdateForwardTip s n d r -> Just (s, n, d, r)
+        _ -> Nothing
+    composeRollback _ (s, n, d, r) =
+        UpdateRollbackMeasured s n d r
+    selectFinalityBegin = \case
+        UpdateFinalityBegin s -> Just s
+        _ -> Nothing
+    selectFinalityEnd = \case
+        UpdateFinalityDone s p -> Just (s, p)
+        _ -> Nothing
+    composeFinality _ (s, p) =
+        UpdateFinalityMeasured s p

--- a/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
@@ -33,7 +33,8 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , RunTransaction (..)
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
-    ( UpdateTrace
+    ( BenchOps
+    , UpdateTrace
     , newSplitState
     , newState
     )
@@ -98,6 +99,7 @@ newRocksDBState
        , MonadMask m
        )
     => Tracer m (UpdateTrace slot hash)
+    -> BenchOps
     -> DB
     -> Prisms slot hash key value
     -> CSMTOps
@@ -116,6 +118,7 @@ newRocksDBState
         )
 newRocksDBState
     tracer
+    benchOps
     db
     prisms
     ops
@@ -123,14 +126,26 @@ newRocksDBState
     onForward
     armageddonParams = do
         runner <- newRunRocksDBTransaction db prisms
-        ensureInitialized runner armageddonParams
+        _ <- ensureInitialized runner armageddonParams
         (,runner)
-            <$> newState tracer ops slotHash onForward armageddonParams runner
+            <$> newState
+                tracer
+                benchOps
+                ops
+                slotHash
+                onForward
+                armageddonParams
+                runner
 
 -- | Create Update state from an existing runner
 createUpdateState
-    :: (MonadFail m, Ord key, Ord slot, Show slot)
+    :: ( MonadFail m
+       , Ord key
+       , Ord slot
+       , Show slot
+       )
     => Tracer m (UpdateTrace slot hash)
+    -> BenchOps
     -> CSMTOps
         (L.Transaction m ColumnFamily (Columns slot hash key value) BatchOp)
         key
@@ -143,17 +158,38 @@ createUpdateState
     -> ArmageddonParams hash
     -> RunTransaction ColumnFamily BatchOp slot hash key value m
     -> m (Update m slot key value, [slot])
-createUpdateState tracer ops slotHash onForward armageddonParams runner = do
-    ensureInitialized runner armageddonParams
-    newState tracer ops slotHash onForward armageddonParams runner
+createUpdateState
+    tracer
+    benchOps
+    ops
+    slotHash
+    onForward
+    armageddonParams
+    runner = do
+        _ <- ensureInitialized runner armageddonParams
+        newState
+            tracer
+            benchOps
+            ops
+            slotHash
+            onForward
+            armageddonParams
+            runner
 
 {- | Create split-mode Update state from an existing runner.
 
 Starts in KVOnly mode if journal is non-empty, otherwise Full.
 -}
 createSplitUpdateState
-    :: (MonadFail m, Ord key, Ord slot, Show slot)
+    :: ( MonadFail m
+       , Ord key
+       , Ord slot
+       , Show slot
+       )
     => Tracer m (UpdateTrace slot hash)
+    -> BenchOps
+    -> Bool
+    -- ^ Whether the DB was freshly initialized (genesis)
     -> CSMTOps
         (L.Transaction m ColumnFamily (Columns slot hash key value) BatchOp)
         key
@@ -177,6 +213,8 @@ createSplitUpdateState
     -> m (Update m slot key value, [slot])
 createSplitUpdateState
     tracer
+    benchOps
+    isGenesis
     kvOps
     fullOps
     replay
@@ -185,9 +223,11 @@ createSplitUpdateState
     onForward
     armageddonParams
     runner = do
-        ensureInitialized runner armageddonParams
+        _ <- ensureInitialized runner armageddonParams
         newSplitState
             tracer
+            benchOps
+            isGenesis
             kvOps
             fullOps
             replay
@@ -200,13 +240,15 @@ createSplitUpdateState
 {- | Ensure the database has been initialized with an Origin rollback point.
 This makes the public API self-initializing so callers can't forget to
 call 'setup' before creating state.
+Returns 'True' if the DB was freshly initialized (genesis).
 -}
 ensureInitialized
     :: (Ord slot, Monad m)
     => RunTransaction cf op slot hash key value m
     -> ArmageddonParams hash
-    -> m ()
+    -> m Bool
 ensureInitialized runner@RunTransaction{transact} armageddonParams = do
     empty <-
         transact $ iterating RollbackPoints $ isNothing <$> firstEntry
     when empty $ setup nullTracer runner armageddonParams
+    pure empty

--- a/lib/Cardano/UTxOCSMT/Application/Metrics.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Metrics.hs
@@ -40,16 +40,25 @@ import Cardano.UTxOCSMT.Application.Metrics.Types
     , renderBlockPoint
     , renderPoint
     , _BaseCheckpointEvent
+    , _BlockDecodeDurationEvent
     , _BlockFetchEvent
     , _BlockInfoEvent
     , _BootstrapPhaseEvent
+    , _CSMTDurationEvent
     , _ChainTipEvent
     , _CountingProgressEvent
     , _DownloadProgressEvent
     , _ExtractionProgressEvent
     , _ExtractionTotalEvent
+    , _FinalityDurationEvent
     , _HeaderSyncProgressEvent
+    , _InternalCsmtOpsEvent
+    , _InternalQueryTipEvent
+    , _InternalRollbackStoreEvent
     , _MerkleRootEvent
+    , _RollbackDurationEvent
+    , _TotalBlockDurationEvent
+    , _TransactionDurationEvent
     , _UTxOChangeEvent
     )
 import Cardano.UTxOCSMT.Ouroboros.Types (Header, Point)
@@ -73,6 +82,7 @@ import Control.Lens
     ( APrism'
     , Lens'
     , aside
+    , clonePrism
     , lens
     , to
     , _Wrapped
@@ -82,23 +92,23 @@ import Control.Tracer (Tracer (..))
 import Data.Profunctor (Profunctor (..))
 import Data.SOP.Strict (index_NS)
 import Data.Time (UTCTime)
-import Data.Tracer.Timestamp (Timestamped (..), timestampTracer)
+import Data.Tracer.Timestamp (Timestamped (..), utcTimestampTracer)
 import Data.Word (Word64)
 import Ouroboros.Consensus.HardFork.Combinator (OneEraHeader (..))
 import Ouroboros.Consensus.HardFork.Combinator qualified as HF
 import Ouroboros.Network.Block (SlotNo (..))
 
 -- | Lens for accessing the event in a 'Timestamped' wrapper
-timestampedEventL :: Lens' (Timestamped a) a
+timestampedEventL :: Lens' (Timestamped t a) a
 timestampedEventL = lens timestampedEvent (\t e -> t{timestampedEvent = e})
 
 -- | Support to use event prisms with 'aside'
-timedAsTuple :: Timestamped a -> (UTCTime, a)
+timedAsTuple :: Timestamped UTCTime a -> (UTCTime, a)
 timedAsTuple (Timestamped t e) = (t, e)
 
 ---------- Metrics specific folds ----------
 
-type TimestampedMetrics = Timestamped MetricsEvent
+type TimestampedMetrics = Timestamped UTCTime MetricsEvent
 
 -- track the last block point seen
 lastBlockPointFold
@@ -122,7 +132,8 @@ maxBlockFetchQueueLength =
         Fold.maximum
 
 -- track speed of some event type
-speedOfSomeEvent :: Int -> APrism' a b -> Fold (Timestamped a) Double
+speedOfSomeEvent
+    :: Int -> APrism' a b -> Fold (Timestamped UTCTime a) Double
 speedOfSomeEvent window prism =
     lmap timedAsTuple
         $ handles (aside prism)
@@ -219,6 +230,43 @@ downloadProgressFold = handles (timestampedEventL . _DownloadProgressEvent) Fold
 countingProgressFold :: Fold TimestampedMetrics (Maybe Word64)
 countingProgressFold = handles (timestampedEventL . _CountingProgressEvent) Fold.last
 
+-- | Average duration in microseconds over a window.
+avgDurationFold
+    :: Int -> APrism' MetricsEvent Double -> Fold TimestampedMetrics Double
+avgDurationFold window prism =
+    handles
+        (timestampedEventL . clonePrism prism . to secsToMicros)
+        $ averageOverWindow window
+  where
+    secsToMicros :: Double -> Double
+    secsToMicros s = s * 1e6
+
+-- | Cumulative sum of durations in microseconds.
+cumulativeDurationFold
+    :: APrism' MetricsEvent Double -> Fold TimestampedMetrics Double
+cumulativeDurationFold prism =
+    handles
+        (timestampedEventL . clonePrism prism . to secsToMicros)
+        Fold.sum
+  where
+    secsToMicros :: Double -> Double
+    secsToMicros s = s * 1e6
+
+-- | Cumulative sum of durations already in microseconds.
+cumulativeUsFold
+    :: APrism' MetricsEvent Double
+    -> Fold TimestampedMetrics Double
+cumulativeUsFold prism =
+    handles
+        (timestampedEventL . clonePrism prism)
+        Fold.sum
+
+-- | Count events matching a prism.
+countEventFold
+    :: APrism' MetricsEvent a -> Fold TimestampedMetrics Int
+countEventFold prism =
+    handles (timestampedEventL . clonePrism prism) Fold.genericLength
+
 -- track the whole set of metrics
 metricsFold :: MetricsParams -> Fold TimestampedMetrics Metrics
 metricsFold MetricsParams{qlWindow, utxoSpeedWindow, blockSpeedWindow} =
@@ -238,6 +286,22 @@ metricsFold MetricsParams{qlWindow, utxoSpeedWindow, blockSpeedWindow} =
         <*> headerSyncProgressFold
         <*> downloadProgressFold
         <*> countingProgressFold
+        <*> avgDurationFold blockSpeedWindow _CSMTDurationEvent
+        <*> avgDurationFold blockSpeedWindow _RollbackDurationEvent
+        <*> avgDurationFold blockSpeedWindow _FinalityDurationEvent
+        <*> avgDurationFold blockSpeedWindow _BlockDecodeDurationEvent
+        <*> avgDurationFold blockSpeedWindow _TransactionDurationEvent
+        <*> avgDurationFold blockSpeedWindow _TotalBlockDurationEvent
+        <*> countEventFold _TotalBlockDurationEvent
+        <*> cumulativeDurationFold _BlockDecodeDurationEvent
+        <*> cumulativeDurationFold _TransactionDurationEvent
+        <*> cumulativeDurationFold _CSMTDurationEvent
+        <*> cumulativeDurationFold _RollbackDurationEvent
+        <*> cumulativeDurationFold _FinalityDurationEvent
+        <*> cumulativeDurationFold _TotalBlockDurationEvent
+        <*> cumulativeUsFold _InternalQueryTipEvent
+        <*> cumulativeUsFold _InternalCsmtOpsEvent
+        <*> cumulativeUsFold _InternalRollbackStoreEvent
 
 -- | Create a metrics tracer that collects metrics and outputs them
 metricsTracer :: MetricsParams -> IO (Tracer IO MetricsEvent)
@@ -261,6 +325,6 @@ metricsTracer params@MetricsParams{metricsFrequency, metricsOutput} = do
         threadDelay metricsFrequency
         readTVarIO metricsV >>= metricsOutput . extract
     pure
-        $ timestampTracer
+        $ utcTimestampTracer
         $ Tracer
         $ \msg -> atomically $ writeTQueue eventsQ msg

--- a/lib/Cardano/UTxOCSMT/Application/Metrics/Types.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Metrics/Types.hs
@@ -31,6 +31,15 @@ module Cardano.UTxOCSMT.Application.Metrics.Types
     , _HeaderSyncProgressEvent
     , _DownloadProgressEvent
     , _CountingProgressEvent
+    , _CSMTDurationEvent
+    , _RollbackDurationEvent
+    , _FinalityDurationEvent
+    , _BlockDecodeDurationEvent
+    , _TransactionDurationEvent
+    , _TotalBlockDurationEvent
+    , _InternalQueryTipEvent
+    , _InternalCsmtOpsEvent
+    , _InternalRollbackStoreEvent
 
       -- * Progress types
     , ExtractionProgress (..)
@@ -144,6 +153,24 @@ data MetricsEvent
       DownloadProgressEvent Word64
     | -- | counting progress (UTxOs counted so far)
       CountingProgressEvent Word64
+    | -- | CSMT operation duration (seconds)
+      CSMTDurationEvent Double
+    | -- | Rollback point storage duration (seconds)
+      RollbackDurationEvent Double
+    | -- | Finality pruning duration (seconds)
+      FinalityDurationEvent Double
+    | -- | Block decode duration (seconds)
+      BlockDecodeDurationEvent Double
+    | -- | Transaction duration (seconds)
+      TransactionDurationEvent Double
+    | -- | Total block processing duration (seconds)
+      TotalBlockDurationEvent Double
+    | -- | Internal queryTip duration (microseconds)
+      InternalQueryTipEvent Double
+    | -- | Internal CSMT ops duration (microseconds)
+      InternalCsmtOpsEvent Double
+    | -- | Internal rollback store duration (microseconds)
+      InternalRollbackStoreEvent Double
     deriving (Show)
 
 makePrisms ''MetricsEvent
@@ -257,6 +284,38 @@ data Metrics = Metrics
     -- ^ Bytes downloaded during Mithril snapshot download
     , countingProgress :: Maybe Word64
     -- ^ UTxOs counted so far during counting phase
+    , avgCSMTDuration :: Double
+    -- ^ Average CSMT operation duration in microseconds
+    , avgRollbackDuration :: Double
+    -- ^ Average rollback point storage duration in microseconds
+    , avgFinalityDuration :: Double
+    -- ^ Average finality pruning duration in microseconds
+    , avgBlockDecodeDuration :: Double
+    -- ^ Average block decode duration in microseconds
+    , avgTransactionDuration :: Double
+    -- ^ Average transaction duration in microseconds
+    , avgTotalBlockDuration :: Double
+    -- ^ Average total block processing duration in microseconds
+    , cumulativeBlocks :: Int
+    -- ^ Total number of blocks processed
+    , cumulativeBlockDecodeDuration :: Double
+    -- ^ Cumulative block decode duration in microseconds
+    , cumulativeTransactionDuration :: Double
+    -- ^ Cumulative transaction duration in microseconds
+    , cumulativeCSMTDuration :: Double
+    -- ^ Cumulative CSMT operation duration in microseconds
+    , cumulativeRollbackDuration :: Double
+    -- ^ Cumulative rollback point storage duration in microseconds
+    , cumulativeFinalityDuration :: Double
+    -- ^ Cumulative finality pruning duration in microseconds
+    , cumulativeTotalBlockDuration :: Double
+    -- ^ Cumulative total block processing duration in microseconds
+    , cumulativeInternalQueryTip :: Double
+    -- ^ Cumulative internal queryTip duration in microseconds
+    , cumulativeInternalCsmtOps :: Double
+    -- ^ Cumulative internal CSMT ops duration in microseconds
+    , cumulativeInternalRollbackStore :: Double
+    -- ^ Cumulative internal rollback store duration in microseconds
     }
     deriving (Show)
 
@@ -278,6 +337,22 @@ instance ToJSON Metrics where
             , headerSyncProgress
             , downloadedBytes
             , countingProgress
+            , avgCSMTDuration
+            , avgRollbackDuration
+            , avgFinalityDuration
+            , avgBlockDecodeDuration
+            , avgTransactionDuration
+            , avgTotalBlockDuration
+            , cumulativeBlocks
+            , cumulativeBlockDecodeDuration
+            , cumulativeTransactionDuration
+            , cumulativeCSMTDuration
+            , cumulativeRollbackDuration
+            , cumulativeFinalityDuration
+            , cumulativeTotalBlockDuration
+            , cumulativeInternalQueryTip
+            , cumulativeInternalCsmtOps
+            , cumulativeInternalRollbackStore
             } =
             object
                 [ "averageQueueLength" .= averageQueueLength
@@ -296,6 +371,31 @@ instance ToJSON Metrics where
                 , "headerSyncProgress" .= headerSyncProgress
                 , "downloadedBytes" .= downloadedBytes
                 , "countingProgress" .= countingProgress
+                , "avgCSMTDuration" .= avgCSMTDuration
+                , "avgRollbackDuration" .= avgRollbackDuration
+                , "avgFinalityDuration" .= avgFinalityDuration
+                , "avgBlockDecodeDuration" .= avgBlockDecodeDuration
+                , "avgTransactionDuration" .= avgTransactionDuration
+                , "avgTotalBlockDuration" .= avgTotalBlockDuration
+                , "cumulativeBlocks" .= cumulativeBlocks
+                , "cumulativeBlockDecodeDuration"
+                    .= cumulativeBlockDecodeDuration
+                , "cumulativeTransactionDuration"
+                    .= cumulativeTransactionDuration
+                , "cumulativeCSMTDuration"
+                    .= cumulativeCSMTDuration
+                , "cumulativeRollbackDuration"
+                    .= cumulativeRollbackDuration
+                , "cumulativeFinalityDuration"
+                    .= cumulativeFinalityDuration
+                , "cumulativeTotalBlockDuration"
+                    .= cumulativeTotalBlockDuration
+                , "cumulativeInternalQueryTip"
+                    .= cumulativeInternalQueryTip
+                , "cumulativeInternalCsmtOps"
+                    .= cumulativeInternalCsmtOps
+                , "cumulativeInternalRollbackStore"
+                    .= cumulativeInternalRollbackStore
                 ]
 
 -- | Render a block point as a string for display
@@ -345,6 +445,46 @@ instance ToSchema Metrics where
                     , ("headerSyncProgress", maybeHeaderSyncProgressSchema)
                     , ("downloadedBytes", maybeWord64Schema)
                     , ("countingProgress", maybeWord64Schema)
+                    , ("avgCSMTDuration", doubleSchema)
+                    , ("avgRollbackDuration", doubleSchema)
+                    , ("avgFinalityDuration", doubleSchema)
+                    , ("avgBlockDecodeDuration", doubleSchema)
+                    , ("avgTransactionDuration", doubleSchema)
+                    , ("avgTotalBlockDuration", doubleSchema)
+                    , ("cumulativeBlocks", intSchema)
+                    ,
+                        ( "cumulativeBlockDecodeDuration"
+                        , doubleSchema
+                        )
+                    ,
+                        ( "cumulativeTransactionDuration"
+                        , doubleSchema
+                        )
+                    , ("cumulativeCSMTDuration", doubleSchema)
+                    ,
+                        ( "cumulativeRollbackDuration"
+                        , doubleSchema
+                        )
+                    ,
+                        ( "cumulativeFinalityDuration"
+                        , doubleSchema
+                        )
+                    ,
+                        ( "cumulativeTotalBlockDuration"
+                        , doubleSchema
+                        )
+                    ,
+                        ( "cumulativeInternalQueryTip"
+                        , doubleSchema
+                        )
+                    ,
+                        ( "cumulativeInternalCsmtOps"
+                        , doubleSchema
+                        )
+                    ,
+                        ( "cumulativeInternalRollbackStore"
+                        , doubleSchema
+                        )
                     ]
             & required
                 .~ [ "averageQueueLength"
@@ -361,7 +501,23 @@ instance ToSchema Metrics where
                    , "extractionProgress"
                    , "headerSyncProgress"
                    , "downloadedBytes"
+                   , "avgCSMTDuration"
+                   , "avgRollbackDuration"
+                   , "avgFinalityDuration"
+                   , "avgBlockDecodeDuration"
+                   , "avgTransactionDuration"
+                   , "avgTotalBlockDuration"
                    , "countingProgress"
+                   , "cumulativeBlocks"
+                   , "cumulativeBlockDecodeDuration"
+                   , "cumulativeTransactionDuration"
+                   , "cumulativeCSMTDuration"
+                   , "cumulativeRollbackDuration"
+                   , "cumulativeFinalityDuration"
+                   , "cumulativeTotalBlockDuration"
+                   , "cumulativeInternalQueryTip"
+                   , "cumulativeInternalCsmtOps"
+                   , "cumulativeInternalRollbackStore"
                    ]
             & description
                 ?~ "Metrics about CSMT operations and blockchain synchronization"

--- a/lib/Cardano/UTxOCSMT/Ouroboros/Types.hs
+++ b/lib/Cardano/UTxOCSMT/Ouroboros/Types.hs
@@ -66,6 +66,9 @@ type family TipOf slot
 -- | The chain tip for a 'Point' is a 'SlotNo'
 type instance TipOf Point = Network.SlotNo
 
+-- | Trivial tip for unit-slot benchmarks
+type instance TipOf () = ()
+
 -- | The header hash type used in the chain sync connection
 type HeaderHash = Network.HeaderHash Block
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -66,4 +66,8 @@ in {
     project.hsPkgs.cardano-utxo-csmt.components.tests.cardano-utxo-csmt-integration-test;
   packages.e2e-tests =
     project.hsPkgs.cardano-utxo-csmt.components.tests.e2e-tests;
+  packages.cardano-utxo-profiled =
+    project.hsPkgs.cardano-utxo-csmt.components.exes.cardano-utxo.profiled;
+  packages.bench-profiled =
+    project.hsPkgs.cardano-utxo-csmt.components.benchmarks.bench.profiled;
 }

--- a/test/Cardano/UTxOCSMT/Application/Database/E2ESpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Database/E2ESpec.hs
@@ -26,6 +26,9 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( mkCSMTOps
     )
+import Cardano.UTxOCSMT.Application.Database.Implementation.Update
+    ( allOps
+    )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
     , State (..)
@@ -132,6 +135,7 @@ withFreshDB action =
                 ((update, _rollbackPoints), _runner) <-
                     newRocksDBState
                         nullTracer
+                        allOps
                         db
                         testPrisms
                         (mkCSMTOps testFromKV testHashing)
@@ -388,6 +392,7 @@ spec = describe "E2E newRocksDBState" $ do
                     ((_, rollbackPoints), _) <-
                         newRocksDBState
                             nullTracer
+                            allOps
                             db
                             testPrisms
                             (mkCSMTOps testFromKV testHashing)

--- a/test/Cardano/UTxOCSMT/Application/Database/RocksDBSpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Database/RocksDBSpec.hs
@@ -41,7 +41,8 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , mkCSMTOps
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
-    ( mkUpdate
+    ( allOps
+    , mkUpdate
     )
 import Cardano.UTxOCSMT.Application.Database.Interface (TipOf)
 import Cardano.UTxOCSMT.Application.Database.Properties
@@ -218,6 +219,7 @@ runRocksDBProperties prop =
     update runner =
         mkUpdate
             nullTracer
+            allOps
             (mkCSMTOps fkv h)
             (const $ mkHash "")
             (\_ _ -> pure ())

--- a/test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
+++ b/test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
@@ -33,7 +33,8 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , queryMerkleRoot
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
-    ( mkUpdate
+    ( allOps
+    , mkUpdate
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
@@ -311,6 +312,7 @@ withTestDB action =
             action runner
                 $ mkUpdate
                     nullTracer
+                    allOps
                     (mkCSMTOps fkv h)
                     testSlotHash
                     (\_ _ -> pure ())
@@ -341,6 +343,7 @@ withTestDBPrefixed action =
             action runner
                 $ mkUpdate
                     nullTracer
+                    allOps
                     (mkCSMTOps fkv h)
                     testSlotHash
                     (\_ _ -> pure ())
@@ -379,6 +382,22 @@ sampleMetrics =
         , headerSyncProgress = Nothing
         , downloadedBytes = Nothing
         , countingProgress = Nothing
+        , avgCSMTDuration = 0.0
+        , avgRollbackDuration = 0.0
+        , avgFinalityDuration = 0.0
+        , avgBlockDecodeDuration = 0.0
+        , avgTransactionDuration = 0.0
+        , avgTotalBlockDuration = 0.0
+        , cumulativeBlocks = 0
+        , cumulativeBlockDecodeDuration = 0.0
+        , cumulativeTransactionDuration = 0.0
+        , cumulativeCSMTDuration = 0.0
+        , cumulativeRollbackDuration = 0.0
+        , cumulativeFinalityDuration = 0.0
+        , cumulativeTotalBlockDuration = 0.0
+        , cumulativeInternalQueryTip = 0.0
+        , cumulativeInternalCsmtOps = 0.0
+        , cumulativeInternalRollbackStore = 0.0
         }
 
 -- | Sample ReadyResponse for synced state

--- a/test/Data/Tracer/ThrottleSpec.hs
+++ b/test/Data/Tracer/ThrottleSpec.hs
@@ -5,7 +5,7 @@ where
 
 import Control.Tracer (Tracer (..), traceWith)
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
-import Data.Time.Clock (UTCTime, addUTCTime)
+import Data.Time.Clock (UTCTime, addUTCTime, diffUTCTime)
 import Data.Tracer.Throttle (Throttled (..), throttleByFrequency)
 import Data.Tracer.Timestamp (Timestamped (..))
 import Test.Hspec (Spec, describe, it, shouldBe)
@@ -15,12 +15,16 @@ collectTracer :: IORef [a] -> Tracer IO a
 collectTracer ref = Tracer $ \a -> modifyIORef' ref (a :)
 
 -- | Helper to create a Timestamped with a specific time
-mkTimestamp :: UTCTime -> String -> Timestamped String
+mkTimestamp :: UTCTime -> String -> Timestamped UTCTime String
 mkTimestamp = Timestamped
 
 -- | Base time for tests
 baseTime :: UTCTime
 baseTime = read "2024-01-01 00:00:00 UTC"
+
+-- | Diff function for throttle tests
+diffSec :: UTCTime -> UTCTime -> Double
+diffSec t1 t2 = realToFrac (diffUTCTime t2 t1)
 
 -- | Add seconds to base time
 addSeconds :: Double -> UTCTime -> UTCTime
@@ -31,7 +35,7 @@ spec = do
     describe "throttleByFrequency" $ do
         it "passes through non-matching events immediately" $ do
             ref <- newIORef []
-            tracer <- throttleByFrequency [] (collectTracer ref)
+            tracer <- throttleByFrequency diffSec [] (collectTracer ref)
             traceWith tracer (mkTimestamp baseTime "event1")
             traceWith tracer (mkTimestamp baseTime "event2")
             results <- reverse <$> readIORef ref
@@ -41,7 +45,7 @@ spec = do
         it "emits first matching event immediately" $ do
             ref <- newIORef []
             let matcher _ = Just 1.0 -- 1 Hz = 1 event per second
-            tracer <- throttleByFrequency [matcher] (collectTracer ref)
+            tracer <- throttleByFrequency diffSec [matcher] (collectTracer ref)
             traceWith tracer (mkTimestamp baseTime "event1")
             results <- readIORef ref
             case results of
@@ -51,7 +55,7 @@ spec = do
         it "drops events within throttle interval" $ do
             ref <- newIORef []
             let matcher _ = Just 1.0 -- 1 Hz = 1 event per second
-            tracer <- throttleByFrequency [matcher] (collectTracer ref)
+            tracer <- throttleByFrequency diffSec [matcher] (collectTracer ref)
             traceWith tracer (mkTimestamp baseTime "event1")
             traceWith tracer (mkTimestamp (addSeconds 0.5 baseTime) "event2")
             traceWith tracer (mkTimestamp (addSeconds 0.9 baseTime) "event3")
@@ -60,7 +64,7 @@ spec = do
         it "reports dropped count when interval passes" $ do
             ref <- newIORef []
             let matcher _ = Just 1.0 -- 1 Hz
-            tracer <- throttleByFrequency [matcher] (collectTracer ref)
+            tracer <- throttleByFrequency diffSec [matcher] (collectTracer ref)
             traceWith tracer (mkTimestamp baseTime "event1")
             traceWith tracer (mkTimestamp (addSeconds 0.3 baseTime) "event2")
             traceWith tracer (mkTimestamp (addSeconds 0.6 baseTime) "event3")
@@ -78,7 +82,7 @@ spec = do
                 matcherB "B" = Just 2.0 -- 2 Hz = 0.5s interval
                 matcherB _ = Nothing
             tracer <-
-                throttleByFrequency [matcherA, matcherB] (collectTracer ref)
+                throttleByFrequency diffSec [matcherA, matcherB] (collectTracer ref)
             traceWith tracer (mkTimestamp baseTime "A")
             traceWith tracer (mkTimestamp baseTime "B")
             traceWith tracer (mkTimestamp (addSeconds 0.3 baseTime) "A")


### PR DESCRIPTION
## Summary

- Replace IO-based clock reads in `forwardTip` with pure Begin/Done trace events measured by `measureDuration` in the tracer pipeline
- Add transact-level timing (`UpdateTransactBegin`/`Done`/`Measured`) covering the full `transact` call including WriteBatch flush
- Wire all three `BenchOps` flags (`doQueryTip`, `doCsmt`, `doRollback`) so each DB operation can be independently toggled
- Remove `UpdateInternalTiming` (was IO-based, now replaced by per-phase `measureDuration`)
- Add genesis bootstrap documentation

## Benchmark results (preprod Babbage, N2C)

| Mode | blk/s |
|---|---|
| Empty transact (`BenchOps False False False`) | ~2300 |
| + queryTip (`True False False`) | ~2300 |
| + CSMT ops (`True True False`) | ~1900 |
| + rollback storage (`True True True`) | ~40 |

Rollback point storage is the dominant bottleneck (47x penalty). See #149 for the fix.

## Test plan

- [ ] CI passes
- [ ] Verify `measureDuration` traces appear in log output
- [ ] Confirm `BenchOps` flags toggle operations independently