### PR TITLE
refactor: derive network magic and epoch slots from genesis

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -34,8 +34,6 @@ import Cardano.UTxOCSMT.Application.Metrics
 import Cardano.UTxOCSMT.Application.Options
     ( ConnectionMode (..)
     , Options (..)
-    , epochSlotsFor
-    , networkMagic
     , optionsParser
     )
 import Cardano.UTxOCSMT.Application.Run.Application
@@ -195,6 +193,8 @@ main = withUtf8 $ do
                 , setupIsGenesis
                 , setupSecurityParam
                 , setupStabilityWindow
+                , setupNetworkMagic
+                , setupEpochSlots
                 } <-
                 setupDB
                     tracer
@@ -255,13 +255,13 @@ main = withUtf8 $ do
             traceWith metricsEvent $ BootstrapPhaseEvent Synced
 
             let epochSlots =
-                    EpochSlots $ epochSlotsFor $ network options
+                    EpochSlots setupEpochSlots
             result <-
                 ( case connectionMode options of
                     N2N{n2nHost, n2nPort} ->
                         application
                             epochSlots
-                            (networkMagic options)
+                            setupNetworkMagic
                             n2nHost
                             n2nPort
                             setupStartingPoint
@@ -275,7 +275,7 @@ main = withUtf8 $ do
                     N2C{n2cSocket} ->
                         applicationN2C
                             epochSlots
-                            (networkMagic options)
+                            setupNetworkMagic
                             n2cSocket
                             setupStartingPoint
                             setCheckpoint

--- a/application/Cardano/UTxOCSMT/Application/Run/Setup.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Setup.hs
@@ -37,7 +37,9 @@ import Cardano.UTxOCSMT.Application.Run.Traces
     ( MainTraces (..)
     )
 import Cardano.UTxOCSMT.Bootstrap.Genesis
-    ( genesisSecurityParam
+    ( genesisEpochSlots
+    , genesisNetworkMagic
+    , genesisSecurityParam
     , genesisStabilityWindow
     , genesisUtxoPairs
     , readByronGenesisUtxoPairs
@@ -59,6 +61,7 @@ import Database.KV.Transaction (iterating)
 import Database.KV.Transaction qualified as L
 import Database.RocksDB (BatchOp, ColumnFamily)
 import Ouroboros.Network.Block qualified as Network
+import Ouroboros.Network.Magic (NetworkMagic)
 import Ouroboros.Network.Point (WithOrigin (..))
 
 {- | Result of database setup containing the starting point
@@ -73,6 +76,10 @@ data SetupResult = SetupResult
     -- ^ Security parameter k from genesis
     , setupStabilityWindow :: Word64
     -- ^ Stability window in slots: @ceiling(3k\/f)@
+    , setupNetworkMagic :: NetworkMagic
+    -- ^ Network magic derived from shelley-genesis.json
+    , setupEpochSlots :: Word64
+    -- ^ Byron epoch slots derived from genesis (10 * k)
     }
 
 {- | Set up the database, potentially bootstrapping from genesis.
@@ -128,7 +135,7 @@ setupDB
         mCheckpoint <- transact $ getBaseCheckpoint decodePoint
         case mCheckpoint of
             Just point -> do
-                (k, sw, _) <- loadGenesis
+                (k, sw, magic, es, _) <- loadGenesis
                 trace $ NotEmpty point
                 return
                     SetupResult
@@ -136,6 +143,8 @@ setupDB
                         , setupIsGenesis = False
                         , setupSecurityParam = k
                         , setupStabilityWindow = sw
+                        , setupNetworkMagic = magic
+                        , setupEpochSlots = es
                         }
             Nothing -> do
                 new <- checkEmptyRollbacks runner
@@ -151,6 +160,8 @@ setupDB
             :: IO
                 ( Word64
                 , Word64
+                , NetworkMagic
+                , Word64
                 , [(LazyByteString, LazyByteString)]
                 )
         loadGenesis = do
@@ -158,6 +169,8 @@ setupDB
             pure
                 ( genesisSecurityParam g
                 , genesisStabilityWindow g
+                , genesisNetworkMagic g
+                , genesisEpochSlots g
                 , genesisUtxoPairs g
                 )
 
@@ -166,7 +179,7 @@ setupDB
 
         regularSetup = do
             setup (contra New) runner armageddonParams
-            (k, sw, shelleyPairs) <- loadGenesis
+            (k, sw, magic, es, shelleyPairs) <- loadGenesis
             -- Load Byron genesis UTxOs
             byronPairs <- case mByronGenesisFile of
                 Just path -> readByronGenesisUtxoPairs path
@@ -188,6 +201,8 @@ setupDB
                     , setupIsGenesis = True
                     , setupSecurityParam = k
                     , setupStabilityWindow = sw
+                    , setupNetworkMagic = magic
+                    , setupEpochSlots = es
                     }
 
 {- | Check if the rollbacks column family is empty.

--- a/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
+++ b/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
@@ -39,9 +39,6 @@ import Cardano.UTxOCSMT.Application.Run.Setup
     , setupDB
     )
 import Control.Tracer (nullTracer)
-import Ouroboros.Network.Magic
-    ( NetworkMagic (..)
-    )
 import System.FilePath ((</>))
 import System.IO.Temp
     ( withSystemTempDirectory
@@ -60,9 +57,6 @@ genesisDir = "e2e-test/genesis"
 shelleyGenesisPath :: FilePath
 shelleyGenesisPath =
     genesisDir </> "shelley-genesis.json"
-
-devnetMagic :: NetworkMagic
-devnetMagic = NetworkMagic 42
 
 spec :: Spec
 spec = describe "Genesis chain sync" $ do
@@ -84,6 +78,8 @@ spec = describe "Genesis chain sync" $ do
                                             prisms
                                     SetupResult
                                         { setupStartingPoint
+                                        , setupNetworkMagic
+                                        , setupEpochSlots
                                         } <-
                                         setupDB
                                             nullTracer
@@ -107,8 +103,8 @@ spec = describe "Genesis chain sync" $ do
                                         timeout
                                             15_000_000
                                             $ applicationN2C
-                                                (EpochSlots 4320)
-                                                devnetMagic
+                                                (EpochSlots setupEpochSlots)
+                                                setupNetworkMagic
                                                 socketPath
                                                 setupStartingPoint
                                                 (\_ -> pure ())

--- a/lib/Cardano/UTxOCSMT/Application/Options.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Options.hs
@@ -6,10 +6,6 @@ module Cardano.UTxOCSMT.Application.Options
     , CardanoNetwork (..)
     , optionsParser
     , optionsParserCore
-
-      -- * Derived option accessors
-    , networkMagic
-    , epochSlotsFor
     )
 where
 
@@ -45,7 +41,6 @@ import OptEnvConf
     , value
     , withYamlConfig
     )
-import Ouroboros.Network.Magic (NetworkMagic (..))
 import Path (Abs, File, Path)
 
 -- | Cardano network selection
@@ -63,20 +58,6 @@ instance HasCodec CardanoNetwork where
 instance HasCodec PortNumber where
     codec =
         dimapCodec fromIntegral (fromIntegral :: PortNumber -> Word16) codec
-
--- | Get network magic for a Cardano network
-networkMagicFor :: CardanoNetwork -> NetworkMagic
-networkMagicFor Mainnet = NetworkMagic 764824073
-networkMagicFor Preprod = NetworkMagic 1
-networkMagicFor Preview = NetworkMagic 2
-networkMagicFor Devnet = NetworkMagic 42
-
--- | Get Byron epoch slots for a Cardano network
-epochSlotsFor :: CardanoNetwork -> Word64
-epochSlotsFor Mainnet = 21600
-epochSlotsFor Preprod = 21600
-epochSlotsFor Preview = 4320
-epochSlotsFor Devnet = 4320
 
 -- | How to connect to a Cardano node
 data ConnectionMode
@@ -107,10 +88,6 @@ data Options = Options
     , byronGenesisFile :: Maybe FilePath
     -- ^ Path to byron-genesis.json for bootstrap from genesis
     }
-
--- | Get effective network magic from options
-networkMagic :: Options -> NetworkMagic
-networkMagic = networkMagicFor . network
 
 -- | Option to specify a YAML configuration file
 configFileOption :: Parser (Maybe (Path Abs File))
@@ -164,8 +141,8 @@ networkOption =
         , conf "network"
         , help
             "Cardano network (mainnet, preprod, preview, devnet). \
-            \Sets network magic and default peer node. \
-            \Use devnet for local Yaci DevKit networks (magic 42)."
+            \Used for default peer node selection. Network magic \
+            \and epoch slots are derived from the genesis file."
         , metavar "NETWORK"
         , reader $ maybeReader readCardanoNetwork
         , value Mainnet

--- a/lib/Cardano/UTxOCSMT/Bootstrap/Genesis.hs
+++ b/lib/Cardano/UTxOCSMT/Bootstrap/Genesis.hs
@@ -11,6 +11,8 @@ module Cardano.UTxOCSMT.Bootstrap.Genesis
     ( readShelleyGenesis
     , genesisSecurityParam
     , genesisStabilityWindow
+    , genesisNetworkMagic
+    , genesisEpochSlots
     , genesisUtxoPairs
     , readByronGenesisUtxoPairs
     )
@@ -55,6 +57,7 @@ import Data.Coerce (coerce)
 import Data.ListMap (unListMap)
 import Data.Map.Strict qualified as Map
 import Data.Word (Word64)
+import Ouroboros.Network.Magic (NetworkMagic (..))
 
 {- | Read and parse a Shelley genesis JSON file.
 Patches @systemStart@ if set to @\"PLACEHOLDER\"@.
@@ -93,6 +96,25 @@ genesisStabilityWindow genesis =
   where
     k = genesisSecurityParam genesis
     f = unboundRational (sgActiveSlotsCoeff genesis)
+
+{- | Extract network magic from Shelley genesis.
+
+The @networkMagic@ field in shelley-genesis.json identifies
+the network (e.g. 764824073 for mainnet, 1 for preprod,
+2 for preview).
+-}
+genesisNetworkMagic :: ShelleyGenesis -> NetworkMagic
+genesisNetworkMagic =
+    NetworkMagic . sgNetworkMagic
+
+{- | Derive Byron epoch slots from the security parameter.
+
+Byron epoch length is @10 * k@ slots where @k@ is the
+security parameter from shelley-genesis.json.
+-}
+genesisEpochSlots :: ShelleyGenesis -> Word64
+genesisEpochSlots genesis =
+    10 * genesisSecurityParam genesis
 
 {- | Extract genesis UTxO pairs as CBOR-encoded (TxIn, TxOut).
 Each initial fund entry becomes a pseudo-TxIn (derived from the


### PR DESCRIPTION
## Summary
- Remove hardcoded `networkMagicFor` and `epochSlotsFor` from `Options.hs`
- Add `genesisNetworkMagic` and `genesisEpochSlots` to `Bootstrap.Genesis` (derived from `shelley-genesis.json`)
- Thread values through `SetupResult` so `Main.hs` and E2E tests use genesis-derived values

Closes #158

## Test plan
- [x] All 69 unit tests pass
- [x] hlint clean
- [x] fourmolu formatted
- [ ] CI green