### PR TITLE
chore: bump haskell-mts to ae6b2b0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -26,8 +26,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: ce79d594ceb26ca80c8e11068877b2a90472cdbe
-  --sha256: 0c9clpdd5whc4kbr8lv82jk94cy51r2qjllpfpc5qb710md54cqc
+  tag: ae6b2b07b85026c4348736b3ae3880b06e98cad4
+  --sha256: 0lym08a1hqxvdv49ccwmxsznfbwmx66a016cm47s3x59hssfplpf
+
+source-repository-package
+  type: git
+  location: https://github.com/paolino/aiken-codegen
+  tag: 74f364c10e930ce2bf47e64b755ede4424733325
+  --sha256: 0rg5hqjix9bs9radzib1ppy09qamxkkqr0hdvc8qm907c21cy2g8
 
 source-repository-package
   type: git


### PR DESCRIPTION
## Summary

- Bump haskell-mts to latest HEAD (patchParallel for parallel CSMT population)
- Add aiken-codegen transitive dependency