### PR TITLE
feat: add mkCSMTKVOnlyOps wrapper for Columns

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -3,17 +3,14 @@ module Cardano.UTxOCSMT.Application.Run.Main
     )
 where
 
-import CSMT.MTS (mkKVOnlyOps)
 import Cardano.Chain.Slotting (EpochSlots (..))
-import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
-    ( Columns (..)
-    )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Query
     ( putBaseCheckpoint
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
     , RunTransaction (..)
+    , mkCSMTKVOnlyOps
     , mkCSMTOps
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
@@ -177,13 +174,9 @@ main = withUtf8 $ do
                     db
                     prisms
             let kvOnlyOps =
-                    mkKVOnlyOps
-                        []
+                    mkCSMTKVOnlyOps
                         4
                         1000
-                        KVCol
-                        CSMTCol
-                        JournalCol
                         (iso BL.toStrict BL.fromStrict)
                         fkv
                         h

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
@@ -3,6 +3,7 @@ module Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , CSMTContext (..)
     , CSMTOps (..)
     , mkCSMTOps
+    , mkCSMTKVOnlyOps
     , queryMerkleRoot
     , queryByAddress
     )
@@ -15,16 +16,19 @@ import CSMT
     )
 import CSMT.Deletion (deleting)
 import CSMT.Interface (Indirect (..), Key, root)
+import CSMT.MTS (Ops, mkKVOnlyOps)
 import CSMT.Proof.Completeness (collectValues)
 import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     ( Columns (..)
     )
-import Control.Lens (review)
+import Control.Lens (Iso', review)
+import Data.ByteString (ByteString)
 import Data.Maybe (catMaybes)
 import Database.KV.Transaction
     ( Transaction
     , query
     )
+import MTS.Interface (Mode (..))
 
 newtype RunTransaction cf op slot hash key value m = RunTransaction
     { transact
@@ -65,6 +69,48 @@ mkCSMTOps fkv h =
         , csmtDelete = deleting [] fkv h KVCol CSMTCol
         , csmtRootHash = root h CSMTCol []
         }
+
+{- | Build KVOnly 'Ops' for the UTxO 'Columns', wiring
+'KVCol', 'CSMTCol', and 'JournalCol' into the
+column-parametric builder from MTS.
+-}
+mkCSMTKVOnlyOps
+    :: (Monad m, Ord key)
+    => Int
+    -- ^ Bucket bits for parallel replay
+    -> Int
+    -- ^ Chunk size for journal batches
+    -> Iso' value ByteString
+    -- ^ Journal value serialization
+    -> FromKV key value hash
+    -> Hashing hash
+    -> ( forall b
+          . Transaction
+                m
+                cf
+                (Columns slot hash key value)
+                op
+                b
+         -> IO b
+       )
+    -- ^ Transaction runner (must be thread-safe)
+    -> Ops
+        'KVOnly
+        m
+        cf
+        (Columns slot hash key value)
+        op
+        key
+        value
+        hash
+mkCSMTKVOnlyOps bucketBits chunkSize =
+    mkKVOnlyOps
+        []
+        bucketBits
+        chunkSize
+        KVCol
+        CSMTCol
+        JournalCol
 
 queryMerkleRoot
     :: Monad m

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
@@ -52,7 +52,7 @@ import Cardano.UTxOCSMT.Application.Database.Interface
     , TipOf
     , Update (..)
     )
-import Control.Monad (forM, forM_, when)
+import Control.Monad (forM, forM_)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans (lift)
 import Control.Tracer (Tracer)
@@ -930,46 +930,89 @@ data SplitMode m slot tip ops = SplitMode
 
 {- | Create a 'SplitMode' backed by the 'Ops' GADT.
 
-In 'MTS.KVOnly', 'afterForward' checks 'isAtTip'; on
+The Ops GADT enforces correctness: 'toFull' replays
+the journal and returns Full ops atomically. The
+caller only sees 'CSMTOps' — the GADT transitions
+are internal.
+
+In 'KVOnly', 'afterForward' checks 'isAtTip'; on
 first @True@ it calls 'toFull' (which replays the
 journal) and switches to 'Full'. Once in 'Full',
 'afterForward' is a no-op.
 -}
 mkSplitMode
-    :: MonadIO m
-    => ops
-    -- ^ KVOnly ops (phase 1)
-    -> ops
-    -- ^ Full ops (phase 2)
-    -> (slot -> tip -> Bool)
+    :: (Monad m)
+    => Ops
+        'MTS.KVOnly
+        m
+        cf
+        (Columns slot hash key value)
+        op
+        key
+        value
+        hash
+    -> (s -> t -> Bool)
     -- ^ Tip proximity predicate
-    -> m ()
-    -- ^ Replay action (journal → tree rebuild)
     -> Phase
     -- ^ Initial phase
-    -> IO (SplitMode m slot tip ops)
-mkSplitMode kvOps fullOps isAtTip replay initial =
-    do
-        phaseRef <- newIORef initial
-        pure
-            SplitMode
-                { currentOps = do
-                    p <- liftIO $ readIORef phaseRef
-                    pure $ case p of
-                        KVOnly -> kvOps
-                        Full -> fullOps
-                , afterForward = \slot tip -> do
-                    p <- liftIO $ readIORef phaseRef
-                    when (p == KVOnly && isAtTip slot tip)
-                        $ do
-                            replay
-                            liftIO
-                                $ writeIORef
-                                    phaseRef
-                                    Full
-                , currentPhase =
-                    liftIO $ readIORef phaseRef
-                }
+    -> IO
+        ( SplitMode
+            IO
+            s
+            t
+            ( CSMTOps
+                ( Transaction
+                    m
+                    cf
+                    (Columns slot hash key value)
+                    op
+                )
+                key
+                value
+                hash
+            )
+        )
+mkSplitMode ops isAtTip initial = do
+    let kvCSMTOps = kvCommonToCSMTOps (kvCommon ops)
+    -- Mutable state: Left = KVOnly, Right = Full CSMTOps
+    initialState <- case initial of
+        KVOnly -> pure (Left kvCSMTOps)
+        Full -> do
+            mFull <- toFull ops
+            case mFull of
+                Just fullOps ->
+                    pure
+                        $ Right
+                        $ fullOpsToCSMTOps fullOps
+                Nothing ->
+                    error
+                        "mkSplitMode: toFull failed on init"
+    ref <- newIORef initialState
+    pure
+        SplitMode
+            { currentOps = do
+                either id id <$> readIORef ref
+            , afterForward = \slot tip -> do
+                st <- readIORef ref
+                case st of
+                    Left _ | isAtTip slot tip -> do
+                        mFull <- toFull ops
+                        case mFull of
+                            Just fullOps ->
+                                writeIORef ref
+                                    $ Right
+                                    $ fullOpsToCSMTOps
+                                        fullOps
+                            Nothing ->
+                                error
+                                    "mkSplitMode: toFull failed"
+                    _ -> pure ()
+            , currentPhase = do
+                st <- readIORef ref
+                pure $ case st of
+                    Left _ -> KVOnly
+                    Right _ -> Full
+            }
 
 -- | Convert KVOnly 'CommonOps' to 'CSMTOps' (root hash always 'Nothing').
 kvCommonToCSMTOps


### PR DESCRIPTION
## Summary
- Add `mkCSMTKVOnlyOps` to Transaction.hs — wires `KVCol`/`CSMTCol`/`JournalCol` into the column-parametric `mkKVOnlyOps` from MTS
- Consumers (MPFS) get a ready-made `Ops 'KVOnly` without touching MTS column selectors
- Main.hs uses `mkCSMTKVOnlyOps` instead of importing from `CSMT.MTS` directly

## Test plan
- [x] `cabal build all -O0` succeeds
- [x] fourmolu + hlint clean
- [ ] Blocked: waiting for MPFS integration to verify