### PR TITLE
feat: hash address prefix for uniform CSMT bucket distribution

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Config.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Config.hs
@@ -7,6 +7,7 @@ module Cardano.UTxOCSMT.Application.Run.Config
     , slotHash
     , encodePoint
     , decodePoint
+    , hashAddressKey
     )
 where
 
@@ -28,6 +29,7 @@ import CSMT.Hashes
     , hashHashing
     , isoHash
     , mkHash
+    , renderHash
     )
 import Cardano.Ledger.Address (unCompactAddr)
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut)
@@ -151,9 +153,19 @@ context =
         , hashing = hashHashing
         }
 
+{- | Hash raw address bytes to a CSMT key.
+
+Hashing produces uniform prefix distribution
+regardless of address type byte, enabling even
+bucket splits for parallel replay.
+-}
+hashAddressKey :: StrictByteString -> Key
+hashAddressKey =
+    byteStringToKey . renderHash . mkHash
+
 -- | Extract address bytes from a CBOR-encoded Conway TxOut, convert to tree key prefix.
 addressPrefix :: StrictByteString -> Key
-addressPrefix cborTxOut = byteStringToKey addressBytes
+addressPrefix cborTxOut = hashAddressKey addressBytes
   where
     addressBytes =
         case decodeFull

--- a/application/Cardano/UTxOCSMT/Application/Run/Query.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Query.hs
@@ -18,7 +18,6 @@ where
 
 import CSMT.Hashes
     ( Hash
-    , byteStringToKey
     , generateInclusionProof
     , renderHash
     )
@@ -38,7 +37,10 @@ import Cardano.UTxOCSMT.Application.Metrics
     ( Metrics (..)
     , SyncPhase (..)
     )
-import Cardano.UTxOCSMT.Application.Run.Config (context)
+import Cardano.UTxOCSMT.Application.Run.Config
+    ( context
+    , hashAddressKey
+    )
 import Cardano.UTxOCSMT.Application.UTxOs (unsafeMkTxIn)
 import Cardano.UTxOCSMT.HTTP.API
     ( InclusionProofResponse (..)
@@ -158,7 +160,7 @@ queryUTxOsByAddress (RunTransaction runTx) addressHex =
         Left err -> pure $ Left $ "Invalid base16 address: " <> err
         Right addressBytes -> do
             let CSMTContext{fromKV} = context
-                addressKey = byteStringToKey addressBytes
+                addressKey = hashAddressKey addressBytes
             results <- runTx $ queryByAddress fromKV addressKey
             pure $ Right $ fmap toEntry results
   where

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
@@ -16,7 +16,11 @@ module Cardano.UTxOCSMT.Application.Database.Implementation.Query
     )
 where
 
-import CSMT.Hashes (byteStringToKey)
+import CSMT.Hashes
+    ( byteStringToKey
+    , mkHash
+    , renderHash
+    )
 import CSMT.Interface (Indirect (..), Key)
 import CSMT.Proof.Completeness (collectValues)
 import Cardano.UTxOCSMT.Application.Database.Implementation.AppConfig
@@ -85,7 +89,11 @@ mkQuery isoK =
                     Nothing -> lift . lift $ fail "No finality point in rollback points"
                     Just e -> pure $ entryKey e
         , getByAddress = \addressBytes -> do
-            let addressKey = byteStringToKey addressBytes
+            let addressKey =
+                    byteStringToKey
+                        . renderHash
+                        . mkHash
+                        $ addressBytes
             indirects <- collectValues CSMTCol [] addressKey
             catMaybes <$> traverse lookupKV indirects
         }


### PR DESCRIPTION
## Summary
- Hash address bytes with blake2b before using as CSMT key prefix
- Uniform bucket distribution regardless of address type byte
- Add `hashAddressKey` helper, used in both insertion and query paths

Closes #170