### PR TITLE
feat: bump MTS with crash recovery + DbState tracing

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -9,9 +9,11 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Query
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
+    , DbState (..)
+    , ReadyState (..)
     , RunTransaction (..)
-    , mkCSMTKVOnlyOps
     , mkCSMTOps
+    , openCSMTOps
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Update
     ( fullForwardOps
@@ -173,15 +175,29 @@ main = withUtf8 $ do
                 newRunRocksDBTransaction
                     db
                     prisms
-            let kvOnlyOps =
-                    mkCSMTKVOnlyOps
-                        4
-                        1000
-                        (iso BL.toStrict BL.fromStrict)
-                        fkv
-                        h
-                        (transact runner)
-                        (trace . JournalReplay)
+            -- Open ops with crash recovery
+            dbState <-
+                openCSMTOps
+                    4
+                    1000
+                    (iso BL.toStrict BL.fromStrict)
+                    fkv
+                    h
+                    (transact runner)
+                    (trace . JournalReplay)
+            -- Resolve DbState: recover if crashed, then
+            -- extract KVOnly ops
+            let resolve (NeedsRecovery recover) = do
+                    trace DbNeedsRecovery
+                    st <- recover
+                    trace DbRecoveryDone
+                    resolve st
+                resolve (Ready (ChooseKVOnly kvOps)) = do
+                    trace DbReadyKVOnly
+                    pure kvOps
+                resolve (Ready (ChooseFull _)) =
+                    fail "openCSMTOps: unexpected ChooseFull"
+            kvOnlyOps <- resolve dbState
 
             let getReadyResponse =
                     mkReadyResponse (syncThreshold options)

--- a/application/Cardano/UTxOCSMT/Application/Run/Traces.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Traces.hs
@@ -92,6 +92,14 @@ data MainTraces
       MetricsReport Metrics
     | -- | Journal replay chunk event
       JournalReplay ReplayEvent
+    | -- | Database opened: crash recovery needed
+      DbNeedsRecovery
+    | -- | Database opened: ready in KVOnly mode
+      DbReadyKVOnly
+    | -- | Database opened: ready in Full mode
+      DbReadyFull
+    | -- | Crash recovery completed
+      DbRecoveryDone
     deriving (Show)
 
 -- | Render a 'MainTraces' value to a human-readable log string.
@@ -133,6 +141,14 @@ renderMainTraces (JournalReplay (ReplayStart cs bs tb ops)) =
         ++ show ops
 renderMainTraces (JournalReplay ReplayStop) =
     "Journal replay: chunk done"
+renderMainTraces DbNeedsRecovery =
+    "Database opened: crash recovery needed (sentinel found)"
+renderMainTraces DbReadyKVOnly =
+    "Database opened: ready in KVOnly mode (journal has entries)"
+renderMainTraces DbReadyFull =
+    "Database opened: ready in Full mode (journal empty)"
+renderMainTraces DbRecoveryDone =
+    "Crash recovery completed"
 renderMainTraces (MetricsReport m) =
     "blocks="
         ++ show (cumulativeBlocks m)

--- a/cabal.project
+++ b/cabal.project
@@ -26,8 +26,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: d7c3e7229205ceb28bf11f5ca3e8477d3363877c
-  --sha256: 1cwkaghcsh39jrg9zkj4d9fjpy616dcdn0li89cxx584xz68dwm8
+  tag: c7bd2c06305ed7361d905c0985e7cbabba028caa
+  --sha256: 16ic11dpdjhxq4a448a4d56rh4gqyixsz0fvlaq60fjxvpig9wqm
 
 source-repository-package
   type: git

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
@@ -3,7 +3,9 @@ module Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , CSMTContext (..)
     , CSMTOps (..)
     , mkCSMTOps
-    , mkCSMTKVOnlyOps
+    , openCSMTOps
+    , DbState (..)
+    , ReadyState (..)
     , ReplayEvent (..)
     , queryMerkleRoot
     , queryByAddress
@@ -17,7 +19,12 @@ import CSMT
     )
 import CSMT.Deletion (deleting)
 import CSMT.Interface (Indirect (..), Key, root)
-import CSMT.MTS (Ops, ReplayEvent (..), mkKVOnlyOps)
+import CSMT.MTS
+    ( DbState (..)
+    , ReadyState (..)
+    , ReplayEvent (..)
+    , openOps
+    )
 import CSMT.Proof.Completeness (collectValues)
 import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     ( Columns (..)
@@ -29,7 +36,6 @@ import Database.KV.Transaction
     ( Transaction
     , query
     )
-import MTS.Interface (Mode (..))
 
 newtype RunTransaction cf op slot hash key value m = RunTransaction
     { transact
@@ -71,12 +77,16 @@ mkCSMTOps fkv h =
         , csmtRootHash = root h CSMTCol []
         }
 
-{- | Build KVOnly 'Ops' for the UTxO 'Columns', wiring
-'KVCol', 'CSMTCol', and 'JournalCol' into the
-column-parametric builder from MTS.
+{- | Open CSMT ops with crash recovery, wiring 'KVCol',
+'CSMTCol', and 'JournalCol' into the column-parametric
+'openOps' from MTS.
+
+Returns 'DbState' which must be resolved before use:
+- 'NeedsRecovery': run recovery action first
+- 'Ready': choose KVOnly or Full mode
 -}
-mkCSMTKVOnlyOps
-    :: (Monad m, Ord key)
+openCSMTOps
+    :: (Monad m, Ord key, Monoid key)
     => Int
     -- ^ Bucket bits for parallel replay
     -> Int
@@ -94,20 +104,21 @@ mkCSMTKVOnlyOps
                 b
          -> IO b
        )
-    -- ^ Transaction runner (must be thread-safe)
+    -- ^ Transaction runner
     -> (ReplayEvent -> IO ())
     -- ^ Trace callback (called per replay chunk)
-    -> Ops
-        'KVOnly
-        m
-        cf
-        (Columns slot hash key value)
-        op
-        key
-        value
-        hash
-mkCSMTKVOnlyOps bucketBits chunkSize =
-    mkKVOnlyOps
+    -> IO
+        ( DbState
+            m
+            cf
+            (Columns slot hash key value)
+            op
+            key
+            value
+            hash
+        )
+openCSMTOps bucketBits chunkSize =
+    openOps
         []
         bucketBits
         chunkSize


### PR DESCRIPTION
## Summary

- Bump haskell-mts to c7bd2c0 (crash recovery sentinel, DbState state machine)
- Use openCSMTOps with DbState resolution: NeedsRecovery runs sentinel cleanup, Ready returns KVOnly ops
- Trace state transitions: DbNeedsRecovery, DbRecoveryDone, DbReadyKVOnly