### PR TITLE
fix: pass unguarded replay runner for parallel journal replay

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -22,6 +22,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Update
 import Cardano.UTxOCSMT.Application.Database.RocksDB
     ( createSplitUpdateState
     , newRunRocksDBTransaction
+    , newRunRocksDBTransactionUnguarded
     )
 import Cardano.UTxOCSMT.Application.Metrics
     ( MetricsEvent (..)
@@ -175,6 +176,10 @@ main = withUtf8 $ do
                 newRunRocksDBTransaction
                     db
                     prisms
+            let unguardedRunner =
+                    newRunRocksDBTransactionUnguarded
+                        db
+                        prisms
             -- Open ops with crash recovery
             dbState <-
                 openCSMTOps
@@ -184,6 +189,7 @@ main = withUtf8 $ do
                     fkv
                     h
                     (transact runner)
+                    (transact unguardedRunner)
                     (trace . JournalReplay)
             -- Resolve DbState: recover if crashed, then
             -- extract KVOnly ops

--- a/cabal.project
+++ b/cabal.project
@@ -26,8 +26,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: c7bd2c06305ed7361d905c0985e7cbabba028caa
-  --sha256: 16ic11dpdjhxq4a448a4d56rh4gqyixsz0fvlaq60fjxvpig9wqm
+  tag: 1a56c7f73cf388adaca6fde8611c2f5965b9e5af
+  --sha256: 0bzc6hm6v9yczcvc39x4whxckdg1p3163iz00khn0dvmlwlkcgdp
 
 source-repository-package
   type: git

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Transaction.hs
@@ -104,7 +104,17 @@ openCSMTOps
                 b
          -> IO b
        )
-    -- ^ Transaction runner
+    -- ^ Guarded runner for normal ops
+    -> ( forall b
+          . Transaction
+                m
+                cf
+                (Columns slot hash key value)
+                op
+                b
+         -> IO b
+       )
+    -- ^ Unguarded runner for parallel replay
     -> (ReplayEvent -> IO ())
     -- ^ Trace callback (called per replay chunk)
     -> IO

--- a/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/RocksDB.hs
@@ -13,6 +13,7 @@ module Cardano.UTxOCSMT.Application.Database.RocksDB
     ( RocksDBTransaction
     , RocksDBQuery
     , newRunRocksDBTransaction
+    , newRunRocksDBTransactionUnguarded
     , newRocksDBState
     , createUpdateState
     , createSplitUpdateState
@@ -89,6 +90,19 @@ newRunTransaction
         )
 newRunTransaction db prisms =
     L.newRunTransaction
+        $ mkRocksDBDatabase db
+        $ mkColumns (columnFamilies db)
+        $ codecs prisms
+
+-- | Create an unguarded 'RunTransaction' for parallel replay.
+newRunRocksDBTransactionUnguarded
+    :: (MonadUnliftIO m, MonadFail m)
+    => DB
+    -> Prisms slot hash key value
+    -> RunTransaction ColumnFamily BatchOp slot hash key value m
+newRunRocksDBTransactionUnguarded db prisms =
+    RunTransaction
+        $ L.runTransactionUnguarded
         $ mkRocksDBDatabase db
         $ mkColumns (columnFamilies db)
         $ codecs prisms


### PR DESCRIPTION
Bump MTS to 1a56c7f (PR #111) and wire the new unguarded runner parameter so journal replay uses `mapConcurrently_` without the MVar lock.

- Add `newRunRocksDBTransactionUnguarded` to RocksDB module
- Update `openCSMTOps` type to accept both guarded and unguarded runners
- Pass unguarded runner in Main.hs for the replay path

Closes #173