### PR TITLE
refactor: persistent rollback counter, remove count threading

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Config.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Config.hs
@@ -102,6 +102,7 @@ withRocksDB path = do
         , ("rollbacks", config)
         , ("config", config)
         , ("journal", config)
+        , ("metrics", config)
         ]
 
 {- | Default RocksDB configuration.

--- a/cabal.project
+++ b/cabal.project
@@ -26,8 +26,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: 1a56c7f73cf388adaca6fde8611c2f5965b9e5af
-  --sha256: 0bzc6hm6v9yczcvc39x4whxckdg1p3163iz00khn0dvmlwlkcgdp
+  tag: 75f358157724208c257b7c9909bdbe89eb5ff337
+  --sha256: 1d715frc74jpqqzm9y4ly5hcbyh4k9ck4k5wq68gd780dn9hknqm
 
 source-repository-package
   type: git

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs
@@ -3,6 +3,7 @@ module Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     , Prisms (..)
     , codecs
     , ConfigKey (..)
+    , rollbackCounter
     )
 where
 
@@ -16,7 +17,10 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.RollbackPoint
     , withOriginPrism
     )
 import Control.Lens (Prism', prism', type (:~:) (Refl))
+import Data.Bits (shiftL, shiftR, (.|.))
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Word (Word64)
 import Database.KV.Transaction
     ( Codecs (..)
     , DMap
@@ -27,6 +31,7 @@ import Database.KV.Transaction
     , KV
     , fromList
     )
+import MTS.Rollbacks.Store (RollbackCounter (..))
 
 -- | Single key for application configuration
 data ConfigKey = AppConfigKey
@@ -58,6 +63,9 @@ data Columns slot hash key value x where
     JournalCol
         :: Columns slot hash key value (KV key ByteString)
         -- ^ Journal column for KVOnly mode replay
+    MetricsCol
+        :: Columns slot hash key value (KV ByteString Int)
+        -- ^ Metrics column for persistent counters
 
 instance GEq (Columns slot hash key value) where
     geq KVCol KVCol = Just Refl
@@ -65,6 +73,7 @@ instance GEq (Columns slot hash key value) where
     geq RollbackPoints RollbackPoints = Just Refl
     geq ConfigCol ConfigCol = Just Refl
     geq JournalCol JournalCol = Just Refl
+    geq MetricsCol MetricsCol = Just Refl
     geq _ _ = Nothing
 
 instance GCompare (Columns slot hash key value) where
@@ -81,7 +90,10 @@ instance GCompare (Columns slot hash key value) where
     gcompare ConfigCol ConfigCol = GEQ
     gcompare ConfigCol _ = GLT
     gcompare JournalCol JournalCol = GEQ
+    gcompare JournalCol MetricsCol = GLT
     gcompare JournalCol _ = GGT
+    gcompare MetricsCol MetricsCol = GEQ
+    gcompare MetricsCol _ = GGT
 
 -- | Prisms for serializing/deserializing keys and values
 data Prisms slot hash key value = Prisms
@@ -114,4 +126,50 @@ codecs Prisms{keyP, hashP, slotP, valueP} =
                 { keyCodec = keyP
                 , valueCodec = prism' id Just
                 }
+        , MetricsCol
+            :=> Codecs
+                { keyCodec = prism' id Just
+                , valueCodec = intPrism
+                }
         ]
+
+-- | Serialize Int as 8-byte big-endian.
+intPrism :: Prism' ByteString Int
+intPrism = prism' encode decode
+  where
+    encode n =
+        let w = fromIntegral n :: Word64
+        in  BS.pack
+                [ fromIntegral (w `shiftR` 56)
+                , fromIntegral (w `shiftR` 48)
+                , fromIntegral (w `shiftR` 40)
+                , fromIntegral (w `shiftR` 32)
+                , fromIntegral (w `shiftR` 24)
+                , fromIntegral (w `shiftR` 16)
+                , fromIntegral (w `shiftR` 8)
+                , fromIntegral w
+                ]
+    decode bs
+        | BS.length bs == 8 =
+            case map fromIntegral $ BS.unpack bs of
+                [a, b, c, d, e, f, g, h] ->
+                    Just
+                        $ fromIntegral @Word64
+                        $ (a `shiftL` 56)
+                            .|. (b `shiftL` 48)
+                            .|. (c `shiftL` 40)
+                            .|. (d `shiftL` 32)
+                            .|. (e `shiftL` 24)
+                            .|. (f `shiftL` 16)
+                            .|. (g `shiftL` 8)
+                            .|. h
+                _ -> Nothing
+        | otherwise = Nothing
+
+-- | Persistent rollback point counter.
+rollbackCounter :: RollbackCounter (Columns slot hash key value)
+rollbackCounter =
+    RollbackCounter
+        { rcSelector = MetricsCol
+        , rcKey = "rollback_count"
+        }

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Update.hs
@@ -36,6 +36,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Armageddon
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     ( Columns (..)
+    , rollbackCounter
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.RollbackPoint
     ( Meta
@@ -52,7 +53,7 @@ import Cardano.UTxOCSMT.Application.Database.Interface
     , TipOf
     , Update (..)
     )
-import Control.Monad (forM, forM_)
+import Control.Monad (forM, forM_, void, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans (lift)
 import Control.Tracer (Tracer)
@@ -74,14 +75,11 @@ import Data.Tracer.TraceWith
 import Database.KV.Cursor
     ( Cursor
     , Entry (..)
-    , firstEntry
     , lastEntry
-    , nextEntry
     , prevEntry
     )
 import Database.KV.Transaction
     ( Transaction
-    , delete
     , iterating
     , query
     )
@@ -318,15 +316,11 @@ newState
     runTransaction@RunTransaction{transact}
     securityParam
     saveCheckpoint = do
-        (cps, rollbackCount) <-
-            transact $ do
-                cps <-
-                    iterating
-                        RollbackPoints
-                        sampleRollbackPoints
-                rollbackCount <-
-                    Store.countPoints RollbackPoints
-                pure (cps, rollbackCount)
+        cps <-
+            transact
+                $ iterating
+                    RollbackPoints
+                    sampleRollbackPoints
         trace $ UpdateNewState cps
         let update =
                 mkUpdate
@@ -339,7 +333,6 @@ newState
                     runTransaction
                     securityParam
                     saveCheckpoint
-                    rollbackCount
         pure (update, cps)
 
 {- | Initialize split-mode state.
@@ -403,16 +396,14 @@ newSplitState
     runTransaction@RunTransaction{transact}
     securityParam
     saveCheckpoint = do
-        (cps, rollbackCount, empty) <-
+        (cps, empty) <-
             transact $ do
                 cps <-
                     iterating
                         RollbackPoints
                         sampleRollbackPoints
-                rollbackCount <-
-                    Store.countPoints RollbackPoints
                 empty <- journalEmptyT JournalCol
-                pure (cps, rollbackCount, empty)
+                pure (cps, empty)
         trace $ UpdateNewState cps
         if empty && not isGenesis
             then do
@@ -433,7 +424,6 @@ newSplitState
                                 runTransaction
                                 securityParam
                                 saveCheckpoint
-                                rollbackCount
                             , cps
                             )
                     Nothing ->
@@ -452,7 +442,6 @@ newSplitState
                         runTransaction
                         securityParam
                         saveCheckpoint
-                        rollbackCount
                     , cps
                     )
 
@@ -471,8 +460,6 @@ forwardTip
         value
         hash
     -> hash
-    -> Int
-    -- ^ rollback point count
     -> slot
     -- ^ slot at which operations happen
     -> [Operation key value]
@@ -488,7 +475,6 @@ forwardTip
     ForwardOps{doQueryTip, doCsmt, doRollback}
     CSMTOps{csmtInsert, csmtDelete, csmtRootHash}
     hash
-    count
     slot
     ops = do
         let io = lift . lift
@@ -496,6 +482,7 @@ forwardTip
             if doQueryTip
                 then queryTip
                 else pure Origin
+        count <- Store.readCount rollbackCounter
         if At slot > tip
             && (not (null ops) || count < 2)
             then do
@@ -565,35 +552,20 @@ updateRollbackPoint
     -> Transaction m cf (Columns slot hash key value) op (Maybe hash)
 updateRollbackPoint rootHashQuery pointHash pointSlot inverseOps = do
     merkleRoot <- rootHashQuery
-    Store.storeRollbackPoint RollbackPoints (At pointSlot)
+    Store.countedStore RollbackPoints rollbackCounter (At pointSlot)
         $ UTxORollbackPoint pointHash inverseOps merkleRoot
     pure merkleRoot
 
 {- | Prune oldest rollback points when count exceeds
-the security parameter k. Returns number pruned.
+the security parameter k.
 -}
 pruneExcess
     :: (Ord slot, Monad m)
     => Int
-    -> Int
     -> RunTransaction cf op slot hash key value m
-    -> m Int
-pruneExcess securityParam currentCount RunTransaction{transact}
-    | excess <= 0 = pure 0
-    | otherwise =
-        transact
-            $ iterating RollbackPoints
-            $ do
-                me <- firstEntry
-                go excess me
-  where
-    excess = currentCount - securityParam
-    go 0 _ = pure 0
-    go _ Nothing = pure 0
-    go n (Just Entry{entryKey}) = do
-        lift $ delete RollbackPoints entryKey
-        next <- nextEntry
-        (+ 1) <$> go (n - 1) next
+    -> m ()
+pruneExcess securityParam RunTransaction{transact} =
+    void $ transact $ Store.pruneExcess RollbackPoints securityParam
 
 sampleRollbackPoints
     :: Monad m
@@ -663,8 +635,6 @@ mkUpdate
                 ()
        )
     -- ^ Save checkpoint (runs inside forwardTip transaction)
-    -> Int
-    -- ^ Initial rollback point count
     -> Update m slot key value
 mkUpdate
     tw@TraceWith{contra, trace}
@@ -678,7 +648,7 @@ mkUpdate
     saveCheckpoint =
         go
       where
-        go count =
+        go =
             Update
                 { forwardTipApply =
                     \slot chainTip operations -> do
@@ -691,23 +661,18 @@ mkUpdate
                                         forwardOps
                                         ops
                                         (slotHash slot)
-                                        count
                                         slot
                                         operations
                                 saveCheckpoint slot
                                 pure r
                         trace $ UpdateTransactDone slot
                         onForward slot chainTip
-                        if stored
-                            then do
-                                let newCount = count + 1
-                                pruned <-
-                                    pruneExcess
-                                        securityParam
-                                        newCount
-                                        runTransaction
-                                pure $ go (newCount - pruned)
-                            else pure $ go count
+                        when stored
+                            $ void
+                            $ pruneExcess
+                                securityParam
+                                runTransaction
+                        pure go
                 , rollbackTipApply = \case
                     At s -> do
                         r <-
@@ -719,25 +684,22 @@ mkUpdate
                                             $ Store.RollbackSucceeded
                                                 0
                                     else
-                                        Store.rollbackTo
+                                        Store.countedRollbackTo
                                             RollbackPoints
+                                            rollbackCounter
                                             ( rollbackRollbackPoint
                                                 ops
                                             )
                                             (At s)
                         case r of
-                            Store.RollbackSucceeded deleted ->
-                                pure
-                                    $ Syncing
-                                    $ go (count - deleted)
+                            Store.RollbackSucceeded _ ->
+                                pure $ Syncing go
                             Store.RollbackImpossible -> do
                                 armageddonCall
-                                pure
-                                    $ Truncating
-                                    $ go 0
+                                pure $ Truncating go
                     Origin -> do
                         armageddonCall
-                        pure $ Syncing $ go 0
+                        pure $ Syncing go
                 }
         armageddonCall =
             armageddon
@@ -789,8 +751,6 @@ mkSplitUpdate
                 ()
        )
     -- ^ Save checkpoint (runs inside forwardTip transaction)
-    -> Int
-    -- ^ Initial rollback point count
     -> Update m slot key value
 mkSplitUpdate
     tw@TraceWith{contra, trace}
@@ -806,7 +766,7 @@ mkSplitUpdate
         goKVOnly
       where
         kvCSMTOps = kvCommonToCSMTOps (kvCommon ops)
-        goKVOnly count =
+        goKVOnly =
             Update
                 { forwardTipApply =
                     \slot chainTip operations -> do
@@ -819,24 +779,17 @@ mkSplitUpdate
                                         kvOnlyForwardOps
                                         kvCSMTOps
                                         (slotHash slot)
-                                        count
                                         slot
                                         operations
                                 saveCheckpoint slot
                                 pure r
                         trace $ UpdateTransactDone slot
                         onForward slot chainTip
-                        count' <-
-                            if stored
-                                then do
-                                    let newCount = count + 1
-                                    pruned <-
-                                        pruneExcess
-                                            securityParam
-                                            newCount
-                                            runTransaction
-                                    pure (newCount - pruned)
-                                else pure count
+                        when stored
+                            $ void
+                            $ pruneExcess
+                                securityParam
+                                runTransaction
                         if isAtTip slot chainTip
                             then do
                                 trace UpdateJournalReplay
@@ -849,13 +802,11 @@ mkSplitUpdate
                                                 ( fullOpsToCSMTOps
                                                     fullOps
                                                 )
-                                                count'
                                     Nothing ->
                                         fail
                                             "mkSplitUpdate: toFull failed"
                             else
-                                pure
-                                    $ goKVOnly count'
+                                pure goKVOnly
                 , rollbackTipApply = \case
                     At s -> do
                         r <-
@@ -867,28 +818,22 @@ mkSplitUpdate
                                             $ Store.RollbackSucceeded
                                                 0
                                     else
-                                        Store.rollbackTo
+                                        Store.countedRollbackTo
                                             RollbackPoints
+                                            rollbackCounter
                                             ( rollbackRollbackPoint
                                                 kvCSMTOps
                                             )
                                             (At s)
                         case r of
-                            Store.RollbackSucceeded deleted ->
-                                pure
-                                    $ Syncing
-                                    $ goKVOnly
-                                        (count - deleted)
+                            Store.RollbackSucceeded _ ->
+                                pure $ Syncing goKVOnly
                             Store.RollbackImpossible -> do
                                 armageddonCall
-                                pure
-                                    $ Truncating
-                                    $ goKVOnly 0
+                                pure $ Truncating goKVOnly
                     Origin -> do
                         armageddonCall
-                        pure
-                            $ Syncing
-                            $ goKVOnly 0
+                        pure $ Syncing goKVOnly
                 }
         goFull fullCSMTOps =
             mkUpdate

--- a/test/Cardano/UTxOCSMT/Application/Database/E2ESpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Database/E2ESpec.hs
@@ -130,6 +130,8 @@ withFreshDB action =
             , ("csmt", testConfig)
             , ("rollbacks", testConfig)
             , ("config", testConfig)
+            , ("journal", testConfig)
+            , ("metrics", testConfig)
             ]
             $ \db -> do
                 ((update, _rollbackPoints), _runner) <-

--- a/test/Cardano/UTxOCSMT/Application/Database/RocksDBSpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Database/RocksDBSpec.hs
@@ -234,7 +234,6 @@ runRocksDBProperties prop =
             runner
             testSecurityParam
             (\_ -> pure ())
-            1 -- Origin rollback point from setup
 
 test
     :: PropertyWithExpected
@@ -414,6 +413,8 @@ withRocksDB path action = do
         , ("csmt", config)
         , ("rollbacks", config)
         , ("config", config)
+        , ("journal", config)
+        , ("metrics", config)
         ]
         $ \db -> do
             action $ RunRocksDB $ flip runReaderT db

--- a/test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
+++ b/test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
@@ -320,7 +320,6 @@ withTestDB action =
                     runner
                     maxBound
                     (\_ -> pure ())
-                    0
 
 -- | Run tests with a fresh RocksDB database using address-prefixed CSMT
 withTestDBPrefixed
@@ -353,7 +352,6 @@ withTestDBPrefixed action =
                     runner
                     maxBound
                     (\_ -> pure ())
-                    0
 
 -- | Open RocksDB with test column families
 withRocksDB :: FilePath -> (DB -> IO b) -> IO b
@@ -365,6 +363,8 @@ withRocksDB path =
         , ("csmt", testConfig)
         , ("rollbacks", testConfig)
         , ("config", testConfig)
+        , ("journal", testConfig)
+        , ("metrics", testConfig)
         ]
 
 -- | Sample metrics for testing


### PR DESCRIPTION
Closes #176

## Summary

- Add MetricsCol for persistent rollback point counter
- Replace `countPoints` O(n) scan with `readCount` O(1) at startup
- Remove count parameter from `mkUpdate`, `mkSplitUpdate`, `forwardTip` — no more continuation threading
- Use MTS counted operations: `countedStore`, `countedRollbackTo`, `pruneExcess`
- Bump haskell-mts to 75f3581 (persistent counter + pruneExcess)