### PR TITLE
refactor: replace WithOrigin with WithSentinel in rollback column keys

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Application.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Application.hs
@@ -37,6 +37,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
+    , WithSentinel (..)
     )
 import Cardano.UTxOCSMT.Application.Metrics
     ( MetricsEvent (..)
@@ -259,7 +260,7 @@ follower
                                 $ processBlock
                                     Rollbacks
                                     securityParam
-                                    (At fetchedPoint)
+                                    (Value fetchedPoint)
                                     (fetchedPoint, ops)
                                     phase
                         pure $ go phase'
@@ -273,7 +274,7 @@ follower
                                         Rollbacks
                                         f
                                         n
-                                        (At point)
+                                        (Value point)
                             case result of
                                 Store.RollbackSucceeded _ ->
                                     pure

--- a/application/Cardano/UTxOCSMT/Application/Run/Query.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Query.hs
@@ -33,6 +33,9 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , queryByAddress
     , queryMerkleRoot
     )
+import Cardano.UTxOCSMT.Application.Database.Interface
+    ( WithSentinel (..)
+    )
 import Cardano.UTxOCSMT.Application.Metrics
     ( Metrics (..)
     , SyncPhase (..)
@@ -92,9 +95,9 @@ queryMerkleRoots (RunTransaction runTx) =
   where
     toMerkleRootEntry (slot, blockHash, merkleRoot) =
         case slot of
-            Origin -> []
-            At (Network.Point Origin) -> []
-            At (Network.Point (At (Block slotNo _))) ->
+            Sentinel -> []
+            Value (Network.Point Origin) -> []
+            Value (Network.Point (At (Block slotNo _))) ->
                 [MerkleRootEntry{slotNo, blockHash, merkleRoot}]
 
 {- | Retrieve the inclusion proof and UTxO value for a transaction input.

--- a/database-test/Cardano/UTxOCSMT/Application/Database/E2ERunnerSpec.hs
+++ b/database-test/Cardano/UTxOCSMT/Application/Database/E2ERunnerSpec.hs
@@ -28,6 +28,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
     , TipOf
+    , WithSentinel (..)
     )
 import Cardano.UTxOCSMT.Application.Database.RocksDB
     ( newRunRocksDBTransaction
@@ -60,7 +61,6 @@ import Database.RocksDB
     , withDBCF
     )
 import Ouroboros.Network.Block (SlotNo (..))
-import Ouroboros.Network.Point (WithOrigin (..))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 import Test.QuickCheck (choose, forAll, ioProperty, property)
@@ -289,7 +289,7 @@ withDBAt dir action =
             transact
                 $ Store.armageddonSetup
                     Rollbacks
-                    Origin
+                    Sentinel
                     Nothing
             -- Start in following mode
             let phase =
@@ -372,7 +372,7 @@ spec = describe "E2E Runner" $ do
                     $ processBlock
                         Rollbacks
                         maxBound
-                        (At (SlotNo 1))
+                        (Value (SlotNo 1))
                         (SlotNo 1, [])
                         phase
             pure ()
@@ -387,7 +387,7 @@ spec = describe "E2E Runner" $ do
                     $ processBlock
                         Rollbacks
                         maxBound
-                        (At (SlotNo 1))
+                        (Value (SlotNo 1))
                         ( SlotNo 1
                         , [Insert key1 val1]
                         )
@@ -400,7 +400,7 @@ spec = describe "E2E Runner" $ do
                     $ processBlock
                         Rollbacks
                         maxBound
-                        (At (SlotNo 2))
+                        (Value (SlotNo 2))
                         ( SlotNo 2
                         , [Insert key2 val2]
                         )
@@ -414,7 +414,7 @@ spec = describe "E2E Runner" $ do
                                 Rollbacks
                                 f
                                 n
-                                (At (SlotNo 1))
+                                (Value (SlotNo 1))
                     case result of
                         Store.RollbackSucceeded deleted ->
                             deleted `shouldBe` 1
@@ -436,7 +436,7 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 1))
+                            (Value (SlotNo 1))
                             ( SlotNo 1
                             , [Insert key1 val1, Insert key2 val2]
                             )
@@ -449,7 +449,7 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 2))
+                            (Value (SlotNo 2))
                             ( SlotNo 2
                             , [Delete key1, Insert key3 val3]
                             )
@@ -460,19 +460,19 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 3))
+                            (Value (SlotNo 3))
                             (SlotNo 3, [])
                             phase2
                 pure ()
 
-    it "rollback to Origin" $ do
+    it "rollback to Sentinel" $ do
         withFreshDB $ \phase transact -> do
             phase1 <-
                 transact
                     $ processBlock
                         Rollbacks
                         maxBound
-                        (At (SlotNo 1))
+                        (Value (SlotNo 1))
                         (SlotNo 1, [])
                         phase
             case phase1 of
@@ -483,7 +483,7 @@ spec = describe "E2E Runner" $ do
                                 Rollbacks
                                 f
                                 n
-                                Origin
+                                Sentinel
                     case result of
                         Store.RollbackSucceeded _ ->
                             pure ()
@@ -502,7 +502,7 @@ spec = describe "E2E Runner" $ do
                     $ processBlock
                         Rollbacks
                         maxBound
-                        (At (SlotNo 1))
+                        (Value (SlotNo 1))
                         ( SlotNo 1
                         , [Insert key1 val1]
                         )
@@ -523,7 +523,7 @@ spec = describe "E2E Runner" $ do
                     $ processBlock
                         Rollbacks
                         1
-                        (At (SlotNo 1))
+                        (Value (SlotNo 1))
                         (SlotNo 1, [])
                         phase
             phase2 <-
@@ -531,7 +531,7 @@ spec = describe "E2E Runner" $ do
                     $ processBlock
                         Rollbacks
                         1
-                        (At (SlotNo 2))
+                        (Value (SlotNo 2))
                         (SlotNo 2, [])
                         phase1
             _ <-
@@ -539,7 +539,7 @@ spec = describe "E2E Runner" $ do
                     $ processBlock
                         Rollbacks
                         1
-                        (At (SlotNo 3))
+                        (Value (SlotNo 3))
                         (SlotNo 3, [])
                         phase2
             -- With k=1, only slot 2 and 3 remain
@@ -591,7 +591,7 @@ spec = describe "E2E Runner" $ do
                     $ processBlock
                         Rollbacks
                         maxBound
-                        (At (SlotNo 1))
+                        (Value (SlotNo 1))
                         ( SlotNo 1
                         , [Insert key366b_0 "out-366b-0"]
                         )
@@ -602,7 +602,7 @@ spec = describe "E2E Runner" $ do
                     $ processBlock
                         Rollbacks
                         maxBound
-                        (At (SlotNo 12903843))
+                        (Value (SlotNo 12903843))
                         ( SlotNo 12903843
                         ,
                             [ Delete key366b_0
@@ -617,7 +617,7 @@ spec = describe "E2E Runner" $ do
                     $ processBlock
                         Rollbacks
                         maxBound
-                        (At (SlotNo 12912634))
+                        (Value (SlotNo 12912634))
                         ( SlotNo 12912634
                         ,
                             [ Delete keyd4be_1
@@ -633,8 +633,8 @@ spec = describe "E2E Runner" $ do
             mTip <-
                 transact
                     $ Store.queryTip Rollbacks
-            -- Fresh DB has sentinel at Origin
-            mTip `shouldBe` Just Origin
+            -- Fresh DB has sentinel at Sentinel
+            mTip `shouldBe` Just Sentinel
 
     describe "Restoration mode" $ do
         it "processes blocks in restoration" $ do
@@ -646,7 +646,7 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 1))
+                            (Value (SlotNo 1))
                             ( SlotNo 1
                             , [Insert key1 val1]
                             )
@@ -664,7 +664,7 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 1))
+                            (Value (SlotNo 1))
                             (SlotNo 1, [Insert (mkTestKey "k") (mkTestValue "v")])
                             phase
                 -- Rollback column should be empty
@@ -683,7 +683,7 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 1))
+                            (Value (SlotNo 1))
                             ( SlotNo 1
                             , [Insert key1 val1]
                             )
@@ -701,7 +701,7 @@ spec = describe "E2E Runner" $ do
                                 $ processBlock
                                     Rollbacks
                                     maxBound
-                                    (At (SlotNo 2))
+                                    (Value (SlotNo 2))
                                     ( SlotNo 2
                                     , [Insert (mkTestKey "utxo2") (mkTestValue "output2")]
                                     )
@@ -723,7 +723,7 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 1))
+                            (Value (SlotNo 1))
                             ( SlotNo 1
                             , [Insert (mkTestKey "utxo1") (mkTestValue "out1")]
                             )
@@ -733,7 +733,7 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 2))
+                            (Value (SlotNo 2))
                             ( SlotNo 2
                             , [Insert (mkTestKey "utxo2") (mkTestValue "out2")]
                             )
@@ -743,7 +743,7 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 3))
+                            (Value (SlotNo 3))
                             ( SlotNo 3
                             , [Insert (mkTestKey "utxo3") (mkTestValue "out3")]
                             )
@@ -757,7 +757,7 @@ spec = describe "E2E Runner" $ do
                         transact
                             $ Store.armageddonSetup
                                 Rollbacks
-                                (At (SlotNo 3))
+                                (Value (SlotNo 3))
                                 Nothing
                         let phase4 =
                                 InFollowing 1 following
@@ -767,7 +767,7 @@ spec = describe "E2E Runner" $ do
                                 $ processBlock
                                     Rollbacks
                                     maxBound
-                                    (At (SlotNo 4))
+                                    (Value (SlotNo 4))
                                     ( SlotNo 4
                                     , [Insert (mkTestKey "utxo4") (mkTestValue "out4")]
                                     )
@@ -777,7 +777,7 @@ spec = describe "E2E Runner" $ do
                                 $ processBlock
                                     Rollbacks
                                     maxBound
-                                    (At (SlotNo 5))
+                                    (Value (SlotNo 5))
                                     ( SlotNo 5
                                     , [Insert (mkTestKey "utxo5") (mkTestValue "out5")]
                                     )
@@ -791,7 +791,7 @@ spec = describe "E2E Runner" $ do
                                             Rollbacks
                                             f
                                             n
-                                            (At (SlotNo 4))
+                                            (Value (SlotNo 4))
                                 case result of
                                     Store.RollbackSucceeded deleted ->
                                         deleted `shouldBe` 1
@@ -817,7 +817,7 @@ spec = describe "E2E Runner" $ do
                                     $ processBlock
                                         Rollbacks
                                         (fromIntegral k)
-                                        (At slot)
+                                        (Value slot)
                                         (slot, [])
                                         p
                             )
@@ -844,7 +844,7 @@ spec = describe "E2E Runner" $ do
                                         $ processBlock
                                             Rollbacks
                                             (fromIntegral k)
-                                            (At slot)
+                                            (Value slot)
                                             (slot, [])
                                             p
                                 )
@@ -863,7 +863,7 @@ spec = describe "E2E Runner" $ do
                                                 Rollbacks
                                                 following
                                                 count
-                                                (At target)
+                                                (Value target)
                                     case result of
                                         Store.RollbackSucceeded _ ->
                                             pure ()
@@ -888,7 +888,7 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 1))
+                            (Value (SlotNo 1))
                             (SlotNo 1, [])
                             phase
                 -- Slot 2: insert key
@@ -897,7 +897,7 @@ spec = describe "E2E Runner" $ do
                         $ processBlock
                             Rollbacks
                             maxBound
-                            (At (SlotNo 2))
+                            (Value (SlotNo 2))
                             ( SlotNo 2
                             , [Insert key1 val1]
                             )
@@ -918,7 +918,7 @@ spec = describe "E2E Runner" $ do
                                     Rollbacks
                                     f
                                     n
-                                    (At (SlotNo 1))
+                                    (Value (SlotNo 1))
                         -- Key from slot 2 should be gone
                         valAfter <-
                             transact
@@ -941,7 +941,7 @@ spec = describe "E2E Runner" $ do
                             $ processBlock
                                 Rollbacks
                                 maxBound
-                                (At (SlotNo 1))
+                                (Value (SlotNo 1))
                                 ( SlotNo 1
                                 , [Insert key1 val1]
                                 )
@@ -951,7 +951,7 @@ spec = describe "E2E Runner" $ do
                             $ processBlock
                                 Rollbacks
                                 maxBound
-                                (At (SlotNo 2))
+                                (Value (SlotNo 2))
                                 ( SlotNo 2
                                 , [Insert key2 val2]
                                 )
@@ -972,7 +972,7 @@ spec = describe "E2E Runner" $ do
                     mTip <-
                         transact
                             $ Store.queryTip Rollbacks
-                    mTip `shouldBe` Just (At (SlotNo 2))
+                    mTip `shouldBe` Just (Value (SlotNo 2))
 
         it "crash + recovery produces same state as clean run" $ do
             let blocks =
@@ -1012,7 +1012,7 @@ spec = describe "E2E Runner" $ do
                                     $ processBlock
                                         Rollbacks
                                         maxBound
-                                        (At slot)
+                                        (Value slot)
                                         (slot, ops)
                                         p
                             go p' rest
@@ -1038,7 +1038,7 @@ spec = describe "E2E Runner" $ do
                                         $ processBlock
                                             Rollbacks
                                             maxBound
-                                            (At slot)
+                                            (Value slot)
                                             (slot, ops)
                                             p
                                 go p' rest
@@ -1054,7 +1054,7 @@ spec = describe "E2E Runner" $ do
                                             $ processBlock
                                                 Rollbacks
                                                 maxBound
-                                                (At slot)
+                                                (Value slot)
                                                 (slot, ops)
                                                 p
                                     go p' rest
@@ -1093,7 +1093,7 @@ spec = describe "E2E Runner" $ do
                                             $ processBlock
                                                 Rollbacks
                                                 maxBound
-                                                (At slot)
+                                                (Value slot)
                                                 (slot, ops)
                                                 p
                                     go p' rest
@@ -1107,7 +1107,7 @@ spec = describe "E2E Runner" $ do
                                             $ processBlock
                                                 Rollbacks
                                                 maxBound
-                                                (At slot)
+                                                (Value slot)
                                                 (slot, ops)
                                                 p
                                     go p' rest

--- a/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
+++ b/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
@@ -29,6 +29,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
     , TipOf
+    , WithSentinel (..)
     )
 import Cardano.UTxOCSMT.Application.Database.RocksDB
     ( newRunRocksDBTransaction
@@ -90,7 +91,6 @@ import Network.Wai.Test
     , setPath
     )
 import Ouroboros.Network.Block (SlotNo (..))
-import Ouroboros.Network.Point (WithOrigin (..))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 
@@ -308,7 +308,7 @@ withFreshDB action =
                 transact
                     $ Store.armageddonSetup
                         Rollbacks
-                        Origin
+                        Sentinel
                         Nothing
                 let phase =
                         InFollowing 1 (mkFollowing csmtOps)
@@ -345,7 +345,7 @@ withFreshDBPrefixed action =
                 transact
                     $ Store.armageddonSetup
                         Rollbacks
-                        Origin
+                        Sentinel
                         Nothing
                 let phase =
                         InFollowing 1 (mkFollowing csmtOps)
@@ -368,7 +368,7 @@ queryTestMerkleRoots (RunTransaction runTx) =
         pure $ concatMap toEntry (reverse history)
   where
     toEntry (slot, RollbackPoint{rpMeta}) = case (slot, rpMeta) of
-        (At slotNo, Just (blockHash, merkleRoot)) ->
+        (Value slotNo, Just (blockHash, merkleRoot)) ->
             [ MerkleRootEntry
                 { slotNo
                 , blockHash
@@ -567,7 +567,7 @@ spec = do
                             $ processBlock
                                 Rollbacks
                                 maxBound
-                                (At (SlotNo 100))
+                                (Value (SlotNo 100))
                                 ( SlotNo 100
                                 , [Insert key1 val1]
                                 )
@@ -579,7 +579,7 @@ spec = do
                             $ processBlock
                                 Rollbacks
                                 maxBound
-                                (At (SlotNo 200))
+                                (Value (SlotNo 200))
                                 ( SlotNo 200
                                 , [Insert key2 val2]
                                 )
@@ -635,7 +635,7 @@ spec = do
                             $ processBlock
                                 Rollbacks
                                 maxBound
-                                (At (SlotNo 100))
+                                (Value (SlotNo 100))
                                 ( SlotNo 100
                                 , [Insert testKey testValue]
                                 )
@@ -708,7 +708,7 @@ spec = do
                             $ processBlock
                                 Rollbacks
                                 maxBound
-                                (At (SlotNo 100))
+                                (Value (SlotNo 100))
                                 ( SlotNo 100
                                 ,
                                     [ Insert key1 value1

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -10,7 +10,7 @@ in [CDDL](https://www.rfc-editor.org/rfc/rfc8610) (RFC 8610).
 |---------------|-----|-------|
 | `kv` | raw bytes (UTxO reference) | raw bytes (CBOR-encoded TxOut) |
 | `csmt` | [Key](#key) | [Indirect](#indirect) |
-| `rollbacks` | [WithOrigin](#withorigin) | [RollbackPoint](#rollbackpoint) |
+| `rollbacks` | [WithSentinel](#withsentinel) | [RollbackPoint](#rollbackpoint) |
 | `config` | UTF-8 literal `"app_config"` | Serialise-encoded tuple |
 
 ## CDDL
@@ -35,10 +35,10 @@ Indirect = [
 ; Column family: rollbacks
 ; ============================================================
 
-; Rollback point key — Origin or a concrete slot.
-WithOrigin = Origin / AtSlot
-Origin  = 0              ; bare uint, not wrapped in array
-AtSlot  = [1, bstr]      ; tag 1 + slot encoded via slot prism
+; Rollback point key — Sentinel or a concrete slot.
+WithSentinel = Sentinel / ValueSlot
+Sentinel   = 0              ; bare uint, not wrapped in array
+ValueSlot  = [1, bstr]      ; tag 1 + slot encoded via slot prism
 
 ; Rollback point value — captures inverse operations for undo.
 RollbackPoint = [
@@ -69,7 +69,7 @@ PointBlock  = [1, uint, bstr]    ; tag 1 + slot number + block hash
   (identity prism). The values are CBOR-encoded Cardano TxOuts but
   their internal structure is opaque to this application.
 - **Hash**: 32-byte Blake2b-256 digest, stored as raw `bstr`.
-- **Slot prism**: the `bstr` in `WithOrigin.AtSlot` is the slot
+- **Slot prism**: the `bstr` in `WithSentinel.ValueSlot` is the slot
   encoded through the same prism used by the application — in
   practice a CBOR-encoded `Point` (see `Point` definition above).
 - **BREAKING**: this schema replaces the previous cereal-based

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Armageddon.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Armageddon.hs
@@ -14,6 +14,9 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
 import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( RunTransaction (..)
     )
+import Cardano.UTxOCSMT.Application.Database.Interface
+    ( WithSentinel (..)
+    )
 import ChainFollower.Rollbacks.Store qualified as Store
 import Control.Monad (when)
 import Control.Monad.Trans (lift)
@@ -29,7 +32,6 @@ import Database.KV.Transaction
     , delete
     , iterating
     )
-import Ouroboros.Network.Point (WithOrigin (..))
 
 data ArmageddonTrace
     = ArmageddonStarted
@@ -122,6 +124,6 @@ setup (traceWith -> trace) (RunTransaction{transact}) armageddonParams = do
     transact
         $ Store.armageddonSetup
             RollbackPoints
-            Origin
+            Sentinel
             (Just (noHash armageddonParams, Nothing))
     trace SetupDone

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs
@@ -12,9 +12,10 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.CSMTCodecs
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.RollbackPoint
     ( RollbackPointKV
+    , WithSentinel
     , rollbackListPrism
     , rollbackPointPrism
-    , withOriginPrism
+    , withSentinelPrism
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation
@@ -32,7 +33,6 @@ import Database.KV.Transaction
     , KV
     , fromList
     )
-import Ouroboros.Network.Point (WithOrigin)
 
 -- | Single key for application configuration
 data ConfigKey = AppConfigKey
@@ -71,7 +71,7 @@ data Columns slot hash key value x where
             key
             value
             ( RollbackKV
-                (WithOrigin slot)
+                (WithSentinel slot)
                 [Operation key value]
                 (hash, Maybe hash)
             )
@@ -123,7 +123,7 @@ codecs Prisms{keyP, hashP, slotP, valueP} =
         , CSMTCol :=> csmtCBORCodecs hashP
         , RollbackPoints
             :=> Codecs
-                { keyCodec = withOriginPrism slotP
+                { keyCodec = withSentinelPrism slotP
                 , valueCodec = rollbackPointPrism hashP keyP valueP
                 }
         , ConfigCol
@@ -138,7 +138,7 @@ codecs Prisms{keyP, hashP, slotP, valueP} =
                 }
         , Rollbacks
             :=> Codecs
-                { keyCodec = withOriginPrism slotP
+                { keyCodec = withSentinelPrism slotP
                 , valueCodec =
                     rollbackListPrism hashP keyP valueP
                 }

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
@@ -41,6 +41,7 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Query (..)
+    , WithSentinel
     , hoistQuery
     )
 import ChainFollower.Rollbacks.Store qualified as Store
@@ -62,7 +63,6 @@ import Database.KV.Transaction
     , iterating
     , query
     )
-import Ouroboros.Network.Point (WithOrigin (..))
 
 -- | Create a query interface
 mkQuery
@@ -125,7 +125,7 @@ getAllMerkleRoots
         cf
         (Columns slot hash key value)
         op
-        [(WithOrigin slot, hash, Maybe hash)]
+        [(WithSentinel slot, hash, Maybe hash)]
 getAllMerkleRoots =
     iterating RollbackPoints $ do
         ml <- lastEntry

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/RollbackPoint.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/RollbackPoint.hs
@@ -17,15 +17,19 @@ module Cardano.UTxOCSMT.Application.Database.Implementation.RollbackPoint
       -- * KV alias
     , RollbackPointKV
 
+      -- * Sentinel wrapper (re-exported from Interface)
+    , WithSentinel (..)
+
       -- * Serialization
     , rollbackPointPrism
     , rollbackListPrism
-    , withOriginPrism
+    , withSentinelPrism
     )
 where
 
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
+    , WithSentinel (..)
     )
 import ChainFollower.Rollbacks.Column (RollbackKV)
 import ChainFollower.Rollbacks.Types qualified as RP
@@ -42,12 +46,11 @@ import Control.Lens
 import Control.Monad (replicateM)
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BL
-import Ouroboros.Network.Point (WithOrigin (..))
 
 -- | KV pair for rollback point storage.
 type RollbackPointKV slot hash key value =
     RollbackKV
-        (WithOrigin slot)
+        (WithSentinel slot)
         (Operation key value)
         (hash, Maybe hash)
 
@@ -201,47 +204,48 @@ rollbackPointPrism hashPrism keyPrism valuePrism =
                     "rollbackPointPrism: invalid\
                     \ operation"
 
--- | Prism for 'WithOrigin' using CBOR encoding.
-withOriginPrism
+-- | Prism for 'WithSentinel' using CBOR encoding.
+withSentinelPrism
     :: forall slot
      . Prism' ByteString slot
-    -> Prism' ByteString (WithOrigin slot)
-withOriginPrism slotP = prism' encode decode
+    -> Prism' ByteString (WithSentinel slot)
+withSentinelPrism slotP = prism' encode decode
   where
-    encode :: WithOrigin slot -> ByteString
-    encode Origin =
+    encode :: WithSentinel slot -> ByteString
+    encode Sentinel =
         encodeCBOR $ CBOR.encodeWord 0
-    encode (At slot) =
+    encode (Value slot) =
         encodeCBOR
             $ CBOR.encodeListLen 2
                 <> CBOR.encodeWord 1
                 <> encodeReview slotP slot
 
-    decode :: ByteString -> Maybe (WithOrigin slot)
+    decode :: ByteString -> Maybe (WithSentinel slot)
     decode = decodeCBOR $ do
         tokenType <- CBOR.peekTokenType
         case tokenType of
             CBOR.TypeUInt -> do
                 tag <- CBOR.decodeWord
                 case tag of
-                    0 -> pure Origin
+                    0 -> pure Sentinel
                     _ ->
                         fail
-                            "withOriginPrism:\
+                            "withSentinelPrism:\
                             \ invalid tag"
             CBOR.TypeListLen -> do
                 _ <- CBOR.decodeListLen
                 tag <- CBOR.decodeWord
                 case tag of
                     1 ->
-                        At <$> decodePreview slotP
+                        Value
+                            <$> decodePreview slotP
                     _ ->
                         fail
-                            "withOriginPrism:\
+                            "withSentinelPrism:\
                             \ invalid tag"
             _ ->
                 fail
-                    "withOriginPrism:\
+                    "withSentinelPrism:\
                     \ unexpected token"
 
 {- | Prism for the new rollback column where

--- a/lib/Cardano/UTxOCSMT/Application/Database/Interface.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Interface.hs
@@ -20,6 +20,9 @@ module Cardano.UTxOCSMT.Application.Database.Interface
     , Operation (..)
     , inverseOp
 
+      -- * Sentinel wrapper
+    , WithSentinel (..)
+
       -- * Update interface
     , Update (..)
     , State (..)
@@ -35,8 +38,14 @@ where
 import Cardano.UTxOCSMT.Ouroboros.Types (TipOf)
 import Data.ByteString (ByteString)
 import Data.List (sortOn)
-import Ouroboros.Network.Point (WithOrigin (..))
 import Prelude hiding (truncate)
+
+{- | Database sentinel wrapper for rollback column keys.
+Unlike ouroboros's 'WithOrigin', this type is explicitly
+a storage concept (sentinel marker), not a chain concept.
+-}
+data WithSentinel a = Sentinel | Value a
+    deriving (Eq, Ord, Show)
 
 -- | Represents an operation on the database
 data Operation key value
@@ -71,7 +80,7 @@ data Update m slot key value = Update
     moving the tip forward
     -}
     , rollbackTipApply
-        :: WithOrigin slot
+        :: WithSentinel slot
         -> m (State m slot key value)
     -- ^ Rollback to the given slot, possibly truncating the database
     }
@@ -80,9 +89,9 @@ data Update m slot key value = Update
 data Query m slot key value = Query
     { getValue :: key -> m (Maybe value)
     -- ^ Look up a value by key
-    , getTip :: m (WithOrigin slot)
+    , getTip :: m (WithSentinel slot)
     -- ^ Get the current tip slot (latest applied)
-    , getFinality :: m (WithOrigin slot)
+    , getFinality :: m (WithSentinel slot)
     -- ^ Get the finality slot (immutable point)
     , getByAddress :: ByteString -> m [(key, value)]
     -- ^ Get all UTxOs at a given address (raw address bytes)
@@ -119,8 +128,8 @@ inverseOp value op = case op of
 
 -- | A dump of the database contents for inspection/testing
 data Dump slot key value = Dump
-    { dumpTip :: WithOrigin slot
-    , dumpFinality :: WithOrigin slot
+    { dumpTip :: WithSentinel slot
+    , dumpFinality :: WithSentinel slot
     , dumpAssocs :: [(key, value)]
     }
     deriving (Show, Eq)
@@ -129,8 +138,8 @@ data Dump slot key value = Dump
 emptyDump :: Dump slot key value
 emptyDump =
     Dump
-        { dumpTip = Origin
-        , dumpFinality = Origin
+        { dumpTip = Sentinel
+        , dumpFinality = Sentinel
         , dumpAssocs = []
         }
 

--- a/lib/Cardano/UTxOCSMT/Application/Database/Properties.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Properties.hs
@@ -20,6 +20,7 @@ import Cardano.UTxOCSMT.Application.Database.Interface
     ( Dump (..)
     , Operation (..)
     , TipOf
+    , WithSentinel (..)
     , emptyDump
     )
 import Cardano.UTxOCSMT.Application.Database.Properties.Expected
@@ -44,7 +45,6 @@ import Control.Monad.State
     )
 import Data.List.NonEmpty (NonEmpty (..), tails, toList)
 import GHC.Stack (HasCallStack)
-import Ouroboros.Network.Point (WithOrigin (..))
 import Test.QuickCheck
     ( Arbitrary (arbitrary)
     , Gen
@@ -89,13 +89,13 @@ assertingJust
 assertingJust msg Nothing _ = assert msg False
 assertingJust _ (Just x) f = f x
 
-genWithOrigin
+genWithSentinel
     :: Gen slot
-    -> Gen (WithOrigin slot)
-genWithOrigin genSlot =
+    -> Gen (WithSentinel slot)
+genWithSentinel genSlot =
     frequency
-        [ (1, return Origin)
-        , (8, fmap At genSlot)
+        [ (1, return Sentinel)
+        , (8, fmap Value genSlot)
         ]
 
 propertyTipIsAfterFinalityOrMissing
@@ -110,11 +110,11 @@ propertyTipIsAfterFinalityOrMissing = do
 
 genSlotAfter
     :: PropertyConstraints m slot key value
-    => WithOrigin slot
+    => WithSentinel slot
     -> PropertyWithExpected m slot key value slot
 genSlotAfter base = do
     Generator{genSlot} <- asksGenerator
-    pick $ genSlot `suchThat` (\s -> At s > base)
+    pick $ genSlot `suchThat` (\s -> Value s > base)
 
 generateOperations
     :: PropertyConstraints m slot key value
@@ -159,7 +159,7 @@ populateWithSomeContent
         slot
         key
         value
-        [(WithOrigin slot, Dump slot key value)]
+        [(WithSentinel slot, Dump slot key value)]
 populateWithSomeContent = do
     NonNegative n <- pick arbitrary
     replicateM n $ do
@@ -168,7 +168,7 @@ populateWithSomeContent = do
         ops <- generateOperations
         forwardTip slot ops
         dump <- getDump
-        pure (At slot, dump)
+        pure (Value slot, dump)
 
 {- | Property: forwarding at or before tip is a no-op
 forwarding must move the tip ahead
@@ -181,8 +181,8 @@ propertyForwardBeforeTipIsNoOp = do
     tipBefore <- getTip
     logOnFailure $ "Current tip: " ++ show tipBefore
     case tipBefore of
-        Origin -> pure ()
-        At tipSlot -> do
+        Sentinel -> pure ()
+        Value tipSlot -> do
             slot <- pick $ genSlot `suchThat` (<= tipSlot)
             ops <- generateOperations
             logOnFailure $ "Forwarding to slot: " ++ show slot
@@ -208,8 +208,8 @@ propertyForwardAfterTipAppliesChanges = do
     Generator{genSlot} <- asksGenerator
     tipBefore <- getTip
     slot <- case tipBefore of
-        Origin -> pick genSlot
-        At tipSlot -> pick $ genSlot `suchThat` (> tipSlot)
+        Sentinel -> pick genSlot
+        Value tipSlot -> pick $ genSlot `suchThat` (> tipSlot)
     ops <- generateOperations
     old@Dump
         { dumpFinality = oldFinality
@@ -233,7 +233,7 @@ propertyForwardAfterTipAppliesChanges = do
         $ newFinality >= oldFinality
     assert
         "Tip should be updated to the newest slot after forwarding"
-        $ newTip == At slot
+        $ newTip == Value slot
     assert
         "Changes were applied correctly after forwarding"
         $ flip all (tails ops)
@@ -263,8 +263,8 @@ propertyRollbackAfterTipDoesNothing = do
     tipBefore <- getTip
     logOnFailure $ "Current tip: " ++ show tipBefore
     slotToRollbackTo <- case tipBefore of
-        Origin -> pure Origin
-        At tipSlot -> pick $ At <$> genSlot `suchThat` (>= tipSlot)
+        Sentinel -> pure Sentinel
+        Value tipSlot -> pick $ Value <$> genSlot `suchThat` (>= tipSlot)
     logOnFailure $ "Rolling back to slot: " ++ show slotToRollbackTo
     oldDump <- getDump
     logOnFailure $ "Old dump: " ++ show oldDump
@@ -281,7 +281,7 @@ rolling back after or at the first one will restore the database to that state
 -}
 propertyRollbackAfterBeforeTipUndoesChanges
     :: PropertyConstraints m slot key value
-    => NonEmpty (WithOrigin slot, Dump slot key value)
+    => NonEmpty (WithSentinel slot, Dump slot key value)
     -> PropertyWithExpected m slot key value ()
 propertyRollbackAfterBeforeTipUndoesChanges history = do
     tip <- getTip
@@ -319,13 +319,13 @@ propertyBlocksDeeperThanKArePruned = do
     finality <- getFinality
     logOnFailure $ "Current finality: " ++ show finality
     case finality of
-        Origin -> pure ()
-        At finalitySlot -> do
+        Sentinel -> pure ()
+        Value finalitySlot -> do
             Generator{genSlot} <- asksGenerator
             slot <-
                 pick
-                    $ genWithOrigin genSlot
-                        `suchThat` (< At finalitySlot)
+                    $ genWithSentinel genSlot
+                        `suchThat` (< Value finalitySlot)
             logOnFailure
                 $ "Rolling back before finality to: "
                     ++ show slot
@@ -343,7 +343,7 @@ should be reachable by rollback.
 -}
 propertyBlocksWithinKAreRollbackable
     :: PropertyConstraints m slot key value
-    => NonEmpty (WithOrigin slot, Dump slot key value)
+    => NonEmpty (WithSentinel slot, Dump slot key value)
     -> PropertyWithExpected m slot key value ()
 propertyBlocksWithinKAreRollbackable history = do
     k <- asksSecurityParam

--- a/lib/Cardano/UTxOCSMT/Application/Database/Properties/Expected.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Properties/Expected.hs
@@ -46,6 +46,7 @@ import Cardano.UTxOCSMT.Application.Database.Interface
     , State (..)
     , TipOf
     , Update (..)
+    , WithSentinel (..)
     , dumpDatabase
     )
 import Cardano.UTxOCSMT.Application.Database.Interface qualified as Interface
@@ -59,7 +60,6 @@ import Control.Monad.State
     )
 import Data.Foldable (Foldable (..))
 import GHC.Stack (HasCallStack)
-import Ouroboros.Network.Point (WithOrigin (..))
 import Test.QuickCheck (Gen)
 import Test.QuickCheck.Monadic (PropertyM, run)
 
@@ -91,7 +91,7 @@ data Context m slot key value = Context
 -- | Expected state of the database
 data Expected slot key value = Expected
     { expectedAssocs :: [(key, value)]
-    , expectedTip :: WithOrigin slot
+    , expectedTip :: WithSentinel slot
     , expectedOpposites :: [(slot, [Operation key value])]
     }
     deriving (Show, Eq)
@@ -100,23 +100,23 @@ emptyExpected :: Expected slot key value
 emptyExpected =
     Expected
         { expectedAssocs = []
-        , expectedTip = Origin
+        , expectedTip = Sentinel
         , expectedOpposites = []
         }
 
 {- | Derive expected finality from the rollback window.
-The DB always starts with an Origin rollback point.
-Finality is Origin until we have more than k opposites
-(meaning Origin has been pruned away).
+The DB always starts with an Sentinel rollback point.
+Finality is Sentinel until we have more than k opposites
+(meaning Sentinel has been pruned away).
 -}
 expectedFinality
-    :: Int -> Expected slot key value -> WithOrigin slot
+    :: Int -> Expected slot key value -> WithSentinel slot
 expectedFinality k Expected{expectedOpposites}
-    | length expectedOpposites < k = Origin
+    | length expectedOpposites < k = Sentinel
     | otherwise =
         case expectedOpposites of
-            [] -> Origin
-            ops -> At . fst $ last ops
+            [] -> Sentinel
+            ops -> Value . fst $ last ops
 
 -- | Number of rollback points currently stored
 expectedRollbackDepth :: Expected slot key value -> Int
@@ -195,13 +195,13 @@ expectedAllOpposites = do
 -- | Proxy to database 'getTip'
 getTip
     :: PropertyConstraints m slot key value
-    => PropertyWithExpected m slot key value (WithOrigin slot)
+    => PropertyWithExpected m slot key value (WithSentinel slot)
 getTip = runDb $ \db -> Interface.getTip db
 
 -- | Proxy to database 'getFinality'
 getFinality
     :: PropertyConstraints m slot key value
-    => PropertyWithExpected m slot key value (WithOrigin slot)
+    => PropertyWithExpected m slot key value (WithSentinel slot)
 getFinality = runDb $ \db -> Interface.getFinality db
 
 -- | Get all expected keys
@@ -209,11 +209,11 @@ expectedKeys :: Expected slot key value -> [key]
 expectedKeys = fmap fst . expectedAssocs
 
 -- | Get the newest expected slot
-expectedNewestSlot :: Expected slot key value -> WithOrigin slot
+expectedNewestSlot :: Expected slot key value -> WithSentinel slot
 expectedNewestSlot Expected{expectedOpposites} =
     case expectedOpposites of
-        [] -> Origin
-        (x : _) -> At . fst $ x
+        [] -> Sentinel
+        (x : _) -> Value . fst $ x
 
 applyOperation :: Eq a => [(a, b)] -> Operation a b -> [(a, b)]
 applyOperation expct (Insert k v) = (k, v) : expct
@@ -252,10 +252,10 @@ expectedForward
     -> [Operation key value]
     -> Expected slot key value
 expectedForward securityParam old@Expected{expectedTip} slot ops
-    | At slot <= expectedTip = old
+    | Value slot <= expectedTip = old
     | otherwise =
         pruneByCount securityParam
-            $ foldl' apply old{expectedTip = At slot} ops
+            $ foldl' apply old{expectedTip = Value slot} ops
   where
     apply ex op =
         ex
@@ -311,7 +311,7 @@ expectedRollback
     :: (Eq key, Ord slot)
     => Int
     -> Expected slot key value
-    -> WithOrigin slot
+    -> WithSentinel slot
     -> Expected slot key value
 expectedRollback
     k
@@ -320,10 +320,10 @@ expectedRollback
         , expectedOpposites = opposites
         , expectedTip
         }
-    (At slot)
-        | At slot >= expectedTip = old
-        | At slot < expectedTip
-            && At slot >= expectedFinality k old =
+    (Value slot)
+        | Value slot >= expectedTip = old
+        | Value slot < expectedTip
+            && Value slot >= expectedFinality k old =
             let
                 (ops, newOpposites) =
                     break (\(slt, _) -> slt <= slot) opposites
@@ -332,18 +332,18 @@ expectedRollback
             in
                 Expected
                     { expectedAssocs = newAssocs
-                    , expectedTip = At slot
+                    , expectedTip = Value slot
                     , expectedOpposites = newOpposites
                     }
         | otherwise = emptyExpected
-expectedRollback _ _ Origin =
+expectedRollback _ _ Sentinel =
     emptyExpected
 
 -- | Proxy to database 'rollback' that also updates expected state
 rollbackTip
     :: forall m slot key value
      . PropertyConstraints m slot key value
-    => WithOrigin slot
+    => WithSentinel slot
     -> PropertyWithExpected m slot key value ()
 rollbackTip newTip = do
     k <- asksSecurityParam

--- a/specs/001-remove-withorigin-key/checklists/requirements.md
+++ b/specs/001-remove-withorigin-key/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Remove WithOrigin Key
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.

--- a/specs/001-remove-withorigin-key/data-model.md
+++ b/specs/001-remove-withorigin-key/data-model.md
@@ -1,0 +1,49 @@
+# Data Model: Replace WithOrigin with WithSentinel
+
+## New Type
+
+```haskell
+data WithSentinel a = Sentinel | Value a
+  deriving (Eq, Ord, Show)
+```
+
+`Ord` instance via deriving: `Sentinel < Value x` for all `x` (constructors ordered by declaration).
+
+## Entity Changes
+
+### RollbackPointKV (before)
+
+```haskell
+type RollbackPointKV slot hash key value =
+    RollbackKV (WithOrigin slot) (Operation key value) (hash, Maybe hash)
+```
+
+### RollbackPointKV (after)
+
+```haskell
+type RollbackPointKV slot hash key value =
+    RollbackKV (WithSentinel slot) (Operation key value) (hash, Maybe hash)
+```
+
+### Wire Format (unchanged)
+
+```
+Sentinel  →  CBOR uint 0
+Value x   →  CBOR [1, x_bytes]
+```
+
+Identical to the old `withOriginPrism` encoding. Existing databases remain compatible.
+
+## Mapping
+
+| Before | After |
+|--------|-------|
+| `WithOrigin slot` | `WithSentinel slot` |
+| `Origin` | `Sentinel` |
+| `At x` | `Value x` |
+| `withOriginPrism` | `withSentinelPrism` |
+| `import Ouroboros.Network.Point (WithOrigin (..))` | `import ...RollbackPoint (WithSentinel (..))` |
+
+## Affected Columns
+
+Both `RollbackPoints` and `Rollbacks` in the `Columns` GADT.

--- a/specs/001-remove-withorigin-key/plan.md
+++ b/specs/001-remove-withorigin-key/plan.md
@@ -1,0 +1,64 @@
+# Implementation Plan: Replace WithOrigin with WithSentinel
+
+**Branch**: `001-remove-withorigin-key` | **Date**: 2026-03-27 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Replace ouroboros's `WithOrigin` with a project-owned `WithSentinel` type for rollback column keys. Same CBOR wire format (backward compatible), clearer semantics, decoupled from ouroboros internals.
+
+## Technical Context
+
+**Language/Version**: Haskell (GHC 9.8.4)
+**Primary Dependencies**: `mts:rollbacks` (generic over key), `rocksdb-kv-transactions`, `ouroboros-network-api` (`Point`, `WithOrigin`)
+**Storage**: RocksDB with CBOR-encoded keys via `Prism' ByteString a`
+**Testing**: HSpec + QuickCheck (unit-tests, database-tests)
+**Target Platform**: Linux (NixOS)
+**Project Type**: Library + HTTP service
+**Constraints**: Wire format preserved — no DB wipe needed
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| Pure core / impure shell | Pass | Change is in pure type/codec layer |
+| Correctness | Pass | Eliminates semantic confusion between chain origin and DB sentinel |
+| Small focused commits | Pass | Single concern: replace WithOrigin with WithSentinel |
+| Test separation | Pass | Unit tests and database tests updated separately |
+| Storage breaking change | N/A | Wire format unchanged, no DB wipe |
+
+No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-remove-withorigin-key/
+├── plan.md
+├── research.md
+├── data-model.md
+└── tasks.md
+```
+
+### Source Code (affected files)
+
+```text
+lib/Cardano/UTxOCSMT/Application/Database/Implementation/
+├── Columns.hs          # GADT key types + codec registration
+├── RollbackPoint.hs    # WithSentinel type + withSentinelPrism + RollbackPointKV
+├── Armageddon.hs       # Sentinel initialization
+└── Query.hs            # Tip/finality/merkle root queries
+
+application/Cardano/UTxOCSMT/Application/Run/
+└── Application.hs      # rollBackward handler
+
+test/Cardano/UTxOCSMT/Application/Database/Implementation/
+└── RollbackPointSpec.hs
+
+database-test/Cardano/UTxOCSMT/Application/Database/
+├── E2ERunnerSpec.hs
+└── ServerSpec.hs (if it uses WithOrigin for rollback keys)
+
+docs/
+└── database-schema.md
+```

--- a/specs/001-remove-withorigin-key/research.md
+++ b/specs/001-remove-withorigin-key/research.md
@@ -1,0 +1,26 @@
+# Research: Replace WithOrigin with WithSentinel
+
+## Decision 1: WithSentinel Type
+
+**Decision**: Define a project-owned `WithSentinel a` type with `Sentinel | Value a` constructors.
+
+**Rationale**: `WithOrigin` from ouroboros conflates chain origin (a chain concept) with database sentinel (a storage concept). When `slot = Point` (which already contains `WithOrigin`), this creates double wrapping with a phantom gap. A dedicated `WithSentinel` type makes the database concern explicit.
+
+**Alternatives considered**:
+- Remove wrapping entirely, use `slot` directly — rejected because tests use `slot = SlotNo` which has no genesis representation. The sentinel concept is needed for all slot types.
+- Keep `WithOrigin` but document the confusion — rejected because the type-level confusion is the root cause of ordering bugs.
+
+## Decision 2: Wire Format Compatibility
+
+**Decision**: Use the same CBOR encoding as `withOriginPrism` (tag 0 = Sentinel, [1, slot] = Value).
+
+**Rationale**: The wire format is sound — it's just the Haskell type wrapping that's confusing. By keeping the same encoding, existing databases remain compatible and no DB wipe is needed.
+
+**Alternatives considered**:
+- New wire format — rejected because it forces a DB wipe for no benefit.
+
+## Decision 3: Module Location
+
+**Decision**: Define `WithSentinel` in `RollbackPoint.hs` alongside the codec.
+
+**Rationale**: It's a small type used only by rollback column keys. No need for a separate module.

--- a/specs/001-remove-withorigin-key/spec.md
+++ b/specs/001-remove-withorigin-key/spec.md
@@ -1,0 +1,77 @@
+# Feature Specification: Replace WithOrigin with WithSentinel in Rollback Column Keys
+
+**Feature Branch**: `001-remove-withorigin-key`
+**Created**: 2026-03-27
+**Status**: Draft
+**Input**: Replace ouroboros `WithOrigin` with a project-owned `WithSentinel` type for rollback column keys, eliminating semantic confusion between chain origin and database sentinel.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Correct Rollback to Genesis (Priority: P1)
+
+When the chain follower receives a `RollBackward Origin` from ChainSync, the system rolls back to genesis without encountering "rollback impossible" errors caused by the semantic mismatch between `WithOrigin.Origin` (chain concept) and the database sentinel.
+
+**Why this priority**: The reuse of ouroboros's `WithOrigin` for the database sentinel creates a phantom gap in the key ordering when `slot = Point` (which already contains `WithOrigin` internally). This is a correctness bug.
+
+**Independent Test**: Initialize a fresh database, insert blocks, roll back to sentinel, verify the state resets correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a database with blocks at slots 1-10, **When** a rollback to sentinel is requested, **Then** the rollback succeeds and the tip returns to `Sentinel`.
+2. **Given** a fresh database with only the sentinel, **When** the tip is queried, **Then** it returns `Sentinel`.
+
+---
+
+### User Story 2 - Clear Sentinel Semantics (Priority: P2)
+
+The database sentinel is a distinct concept from chain origin. The type system makes this explicit via a project-owned `WithSentinel` type.
+
+**Why this priority**: Using ouroboros's `WithOrigin` conflates two distinct concerns: chain position (origin = before genesis block) and database initialization marker (sentinel = before any data). The `WithSentinel` type makes the database concern explicit and decouples from ouroboros internals.
+
+**Independent Test**: Verify that `Sentinel` is strictly less than any `Value slot` in key ordering, regardless of the concrete `slot` type.
+
+**Acceptance Scenarios**:
+
+1. **Given** `WithSentinel` with `Ord` instance, **When** comparing `Sentinel` with `Value x` for any `x`, **Then** `Sentinel < Value x`.
+2. **Given** rollback column key type is `WithSentinel slot`, **When** the code is compiled, **Then** no `Ouroboros.Network.Point.WithOrigin` appears in rollback key types or codecs.
+
+---
+
+### Edge Cases
+
+- Empty database (no sentinel): system fails with a clear error as today.
+- Rollback to a point not in the store: `seekKey` returns `RollbackImpossible` as before.
+- Existing databases with old codec: incompatible, must be wiped.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A new `WithSentinel a` type MUST be defined with constructors `Sentinel` and `Value a`, with `Eq`, `Ord`, `Show` instances where `Sentinel < Value x` for all `x`.
+- **FR-002**: The `RollbackPoints` and `Rollbacks` columns MUST use `WithSentinel slot` as their key type instead of `WithOrigin slot`.
+- **FR-003**: A new `withSentinelPrism` codec MUST replace `withOriginPrism`, using the same CBOR wire format for backward compatibility (tag 0 = Sentinel, [1, slot] = Value).
+- **FR-004**: All call sites MUST replace `Origin` with `Sentinel` and `At x` with `Value x`.
+- **FR-005**: The `withOriginPrism` function MUST be removed.
+- **FR-006**: The `WithOrigin` import from ouroboros MUST be removed from all rollback key code (it may remain for non-key uses like `pointSlot`).
+- **FR-007**: The database schema documentation MUST reflect the new type name.
+
+### Key Entities
+
+- **WithSentinel a**: New sum type replacing `WithOrigin` for rollback keys. Sentinel = database initialization marker, Value = actual slot data.
+- **RollbackPointKV**: Type alias updated from `WithOrigin slot` to `WithSentinel slot`.
+- **Rollbacks/RollbackPoints**: GADT constructors updated similarly.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All existing unit and database tests pass with updated assertions.
+- **SC-002**: `WithOrigin` does not appear in any rollback column key type or codec.
+- **SC-003**: E2E runner tests demonstrate correct rollback to sentinel with the new type.
+- **SC-004**: Wire format is identical to the old codec (no DB wipe needed if format preserved).
+
+## Assumptions
+
+- Wire format compatibility: if the CBOR encoding is identical (tag 0 = Sentinel, [1, slot] = Value), existing databases remain compatible and no wipe is needed.
+- The upstream `mts:rollbacks` library is generic over `key` — no upstream changes needed.
+- `WithSentinel` is defined in the RollbackPoint module alongside the codecs.

--- a/specs/001-remove-withorigin-key/tasks.md
+++ b/specs/001-remove-withorigin-key/tasks.md
@@ -1,0 +1,84 @@
+# Tasks: Replace WithOrigin with WithSentinel
+
+**Input**: Design documents from `/specs/001-remove-withorigin-key/`
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+
+## Phase 1: Define WithSentinel Type
+
+**Purpose**: Introduce the new type and codec before changing any consumers.
+
+- [ ] T001 [US2] Define `WithSentinel a` type with `Sentinel | Value a` constructors (deriving `Eq`, `Ord`, `Show`) and `withSentinelPrism` codec in `lib/Cardano/UTxOCSMT/Application/Database/Implementation/RollbackPoint.hs`
+- [ ] T002 [US2] Export `WithSentinel (..)` and `withSentinelPrism` from module header, keep old exports temporarily
+
+**Checkpoint**: New type exists alongside old code. Everything still compiles.
+
+---
+
+## Phase 2: Switch Column Types
+
+**Purpose**: Update GADT and type alias to use `WithSentinel`. Compiler errors guide remaining work.
+
+- [ ] T003 [US1] Change `RollbackPointKV` type alias from `WithOrigin slot` to `WithSentinel slot` in `lib/Cardano/UTxOCSMT/Application/Database/Implementation/RollbackPoint.hs`
+- [ ] T004 [US1] Change `Rollbacks` GADT constructor key type from `WithOrigin slot` to `WithSentinel slot` in `lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs`
+- [ ] T005 [US1] Update codec registration from `withOriginPrism slotP` to `withSentinelPrism slotP` in `lib/Cardano/UTxOCSMT/Application/Database/Implementation/Columns.hs`
+
+**Checkpoint**: Types changed — compiler errors appear at all call sites.
+
+---
+
+## Phase 3: Fix Call Sites (Priority: P1)
+
+**Goal**: All rollback operations compile and work with `WithSentinel`.
+
+- [ ] T006 [US1] Replace `Origin` with `Sentinel` in sentinel setup in `lib/Cardano/UTxOCSMT/Application/Database/Implementation/Armageddon.hs`
+- [ ] T007 [P] [US1] Update `getAllMerkleRoots` return type from `WithOrigin slot` to `WithSentinel slot` in `lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs`
+- [ ] T008 [P] [US1] Replace `At point` with `Value point` in `processBlock` and `rollbackTo` calls in `application/Cardano/UTxOCSMT/Application/Run/Application.hs`
+
+**Checkpoint**: Library and application compile.
+
+---
+
+## Phase 4: Update Tests
+
+- [ ] T009 [P] [US1] Replace all `Origin` with `Sentinel` and `At x` with `Value x` in `database-test/Cardano/UTxOCSMT/Application/Database/E2ERunnerSpec.hs`
+- [ ] T010 [P] [US1] Replace `Origin`/`At` with `Sentinel`/`Value` in `database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs`
+- [ ] T011 [P] [US2] Update `withOriginPrism` tests to test `withSentinelPrism` in `test/Cardano/UTxOCSMT/Application/Database/Implementation/RollbackPointSpec.hs`
+
+**Checkpoint**: All tests compile and pass.
+
+---
+
+## Phase 5: Remove Dead Code
+
+- [ ] T012 [US2] Remove `withOriginPrism` function and its export from `lib/Cardano/UTxOCSMT/Application/Database/Implementation/RollbackPoint.hs`
+- [ ] T013 Remove unused `WithOrigin` imports from all changed files
+- [ ] T014 Update CDDL schema — rename `WithOrigin` to `WithSentinel` in `docs/database-schema.md`
+
+---
+
+## Phase 6: Polish
+
+- [ ] T015 Run `just format` and `just cabal-check`
+- [ ] T016 Verify build: `cabal build unit-tests database-tests`
+- [ ] T017 Run tests: `cabal test unit-tests` and `cabal test database-tests`
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1** (T001-T002): No deps — new code alongside old
+- **Phase 2** (T003-T005): Sequential, depends on Phase 1
+- **Phase 3** (T006-T008): Depends on Phase 2. T007 and T008 parallel.
+- **Phase 4** (T009-T011): Depends on Phase 3. All three parallel.
+- **Phase 5** (T012-T014): Depends on Phase 4.
+- **Phase 6** (T015-T017): Depends on Phase 5.
+
+## Notes
+
+- Wire format is identical — no DB wipe needed
+- Single commit: all tasks are one logical concern (replace WithOrigin with WithSentinel)
+- 17 tasks across 6 phases

--- a/test/Cardano/UTxOCSMT/Application/Database/Implementation/RollbackPointSpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Database/Implementation/RollbackPointSpec.hs
@@ -6,10 +6,11 @@ where
 import Cardano.UTxOCSMT.Application.Database.Implementation.RollbackPoint
     ( rollbackListPrism
     , rollbackPointPrism
-    , withOriginPrism
+    , withSentinelPrism
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
+    , WithSentinel (..)
     )
 import ChainFollower.Rollbacks.Types qualified as RP
 import Control.Lens
@@ -20,7 +21,6 @@ import Control.Lens
     )
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
-import Ouroboros.Network.Point (WithOrigin (..))
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.QuickCheck
     ( Gen
@@ -82,26 +82,26 @@ genRollbackListPoint = do
             , rpMeta = Just (h, mr)
             }
 
-genWithOrigin :: Gen (WithOrigin ByteString)
-genWithOrigin =
+genWithSentinel :: Gen (WithSentinel ByteString)
+genWithSentinel =
     oneof
-        [ pure Origin
-        , At <$> genBS
+        [ pure Sentinel
+        , Value <$> genBS
         ]
 
 spec :: Spec
 spec = describe "RollbackPoint" $ do
-    describe "withOriginPrism" $ do
-        it "roundtrips Origin" $ do
-            roundtrip (withOriginPrism idPrism) Origin
+    describe "withSentinelPrism" $ do
+        it "roundtrips Sentinel" $ do
+            roundtrip (withSentinelPrism idPrism) Sentinel
 
-        it "roundtrips At slot" $ do
+        it "roundtrips Value slot" $ do
             forAll genBS $ \slot ->
-                roundtrip (withOriginPrism idPrism) (At slot)
+                roundtrip (withSentinelPrism idPrism) (Value slot)
 
-        it "roundtrips arbitrary WithOrigin" $ do
-            forAll genWithOrigin $ \wo ->
-                roundtrip (withOriginPrism idPrism) wo
+        it "roundtrips arbitrary WithSentinel" $ do
+            forAll genWithSentinel $ \wo ->
+                roundtrip (withSentinelPrism idPrism) wo
 
     describe "rollbackPointPrism" $ do
         it "roundtrips a rollback point" $ do

--- a/test/Cardano/UTxOCSMT/Application/Database/InterfaceSpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Database/InterfaceSpec.hs
@@ -3,13 +3,13 @@ module Cardano.UTxOCSMT.Application.Database.InterfaceSpec (spec) where
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
     , Query (..)
+    , WithSentinel (..)
     , hoistQuery
     , inverseOp
     )
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.Functor.Identity (Identity (..))
-import Ouroboros.Network.Point (WithOrigin (..))
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.QuickCheck (Gen, arbitrary, forAll)
 
@@ -48,8 +48,8 @@ spec = describe "Database.Interface" $ do
                 let q =
                         Query
                             { getValue = \_ -> Identity (Just bs)
-                            , getTip = Identity Origin
-                            , getFinality = Identity Origin
+                            , getTip = Identity Sentinel
+                            , getFinality = Identity Sentinel
                             , getByAddress = \_ -> Identity []
                             }
                     q' = hoistQuery id q
@@ -59,9 +59,9 @@ spec = describe "Database.Interface" $ do
             let q =
                     Query
                         { getValue = \_ -> Identity (Nothing :: Maybe ByteString)
-                        , getTip = Identity (At (42 :: Int))
-                        , getFinality = Identity Origin
+                        , getTip = Identity (Value (42 :: Int))
+                        , getFinality = Identity Sentinel
                         , getByAddress = \_ -> Identity []
                         }
                 q' = hoistQuery id q
-            runIdentity (getTip q') `shouldBe` At 42
+            runIdentity (getTip q') `shouldBe` Value 42


### PR DESCRIPTION
## Summary
- Introduce `WithSentinel a` type (`Sentinel | Value a`) for rollback column keys
- Replaces ouroboros's `WithOrigin` which conflated chain origin with database sentinel semantics
- Same CBOR wire format (tag 0 = Sentinel, [1, slot] = Value) — no DB wipe needed
- Includes speckit spec/plan/tasks artifacts

Closes #134