### PR TITLE
feat: add push-based UTxO await via TVar notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ cabal.project.local
 .ghc*
 .llm/
 WIP.md
+.clj-kondo/.cache/v1/lock
+.lsp/.cache/db.transit.json

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -51,6 +51,11 @@ Everything builds via `flake.nix`. CI and local development use the exact same n
 - `just ci` locally before pushing.
 - Format with `fourmolu`, lint with `hlint`, check with `cabal check`.
 
+## Documentation Standards
+
+- Diagrams in markdown MUST use Mermaid syntax (rendered by MkDocs mermaid2 plugin and GitHub).
+- No ASCII art diagrams — always use Mermaid flowcharts, sequence diagrams, or class diagrams.
+
 ## Governance
 
 Constitution reflects the project's established practices. Amendments are committed alongside the changes that motivate them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# cardano-utxo-csmt-issue-151 Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2026-03-27
+
+## Active Technologies
+
+- Haskell (GHC 9.8.4) + `stm` (TVar, STM), `servant-server` (HTTP API), `rocksdb-kv-transactions` (002-await-value)
+
+## Project Structure
+
+```text
+src/
+tests/
+```
+
+## Commands
+
+# Add commands for Haskell (GHC 9.8.4)
+
+## Code Style
+
+Haskell (GHC 9.8.4): Follow standard conventions
+
+## Recent Changes
+
+- 002-await-value: Added Haskell (GHC 9.8.4) + `stm` (TVar, STM), `servant-server` (HTTP API), `rocksdb-kv-transactions`
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/application/Cardano/UTxOCSMT/Application/Run/Application.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Application.hs
@@ -59,6 +59,7 @@ import Cardano.UTxOCSMT.Ouroboros.Types
 import ChainFollower.Backend qualified as Backend
 import ChainFollower.Rollbacks.Store qualified as Store
 import ChainFollower.Runner (Phase (..))
+import Control.Concurrent.STM (TVar, atomically, modifyTVar')
 import Control.Exception (throwIO)
 import Control.Monad (replicateM_)
 import Control.Tracer (Tracer (..))
@@ -166,6 +167,8 @@ intersector
     -> ArmageddonParams Hash
     -> Int
     -- ^ Security parameter (stability window)
+    -> TVar Int
+    -- ^ Commit notification counter
     -> AppPhase
     -> Intersector Point SlotNo Fetched
 intersector
@@ -175,6 +178,7 @@ intersector
     backendInit
     armageddonParams
     securityParam
+    notifyTVar
     phase =
         Intersector
             { intersectFound = \point -> do
@@ -187,6 +191,7 @@ intersector
                         backendInit
                         armageddonParams
                         securityParam
+                        notifyTVar
                         phase
             , intersectNotFound = do
                 trace ApplicationIntersectionFailed
@@ -198,6 +203,7 @@ intersector
                         backendInit
                         armageddonParams
                         securityParam
+                        notifyTVar
                         phase
                     , [origin]
                     )
@@ -225,6 +231,8 @@ follower
     -> ArmageddonParams Hash
     -> Int
     -- ^ Security parameter (stability window)
+    -> TVar Int
+    -- ^ Commit notification counter
     -> AppPhase
     -> Follower Point SlotNo Fetched
 follower
@@ -233,7 +241,8 @@ follower
     runner@RunTransaction{transact}
     backendInit
     armageddonParams
-    securityParam =
+    securityParam
+    notifyTVar =
         go
       where
         go phase =
@@ -263,6 +272,7 @@ follower
                                     (Value fetchedPoint)
                                     (fetchedPoint, ops)
                                     phase
+                        atomically $ modifyTVar' notifyTVar (+ 1)
                         pure $ go phase'
                 , rollBackward = \point -> do
                     trace $ ApplicationRollingBack point
@@ -307,6 +317,7 @@ follower
                                                 backendInit
                                                 armageddonParams
                                                 securityParam
+                                                notifyTVar
                                                 ( InRestoration
                                                     0
                                                     restoring
@@ -346,6 +357,8 @@ application
     -> ArmageddonParams Hash
     -> Int
     -- ^ Security parameter (stability window)
+    -> TVar Int
+    -- ^ Commit notification counter
     -> AppPhase
     -> [Point]
     -> IO Void
@@ -363,6 +376,7 @@ application
     backendInit
     armageddonParams
     securityParam
+    notifyTVar
     initialPhase
     availablePoints =
         do
@@ -387,6 +401,7 @@ application
                         backendInit
                         armageddonParams
                         securityParam
+                        notifyTVar
                         initialPhase
             let chainFollowingApplication =
                     mkChainSyncApplication
@@ -442,6 +457,8 @@ applicationN2C
     -> ArmageddonParams Hash
     -> Int
     -- ^ Security parameter (stability window)
+    -> TVar Int
+    -- ^ Commit notification counter
     -> AppPhase
     -> [Point]
     -> IO Void
@@ -457,6 +474,7 @@ applicationN2C
     backendInit
     armageddonParams
     securityParam
+    notifyTVar
     initialPhase
     availablePoints =
         do
@@ -473,6 +491,7 @@ applicationN2C
                         backendInit
                         armageddonParams
                         securityParam
+                        notifyTVar
                         initialPhase
                 points =
                     if null availablePoints

--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -50,6 +50,7 @@ import Cardano.UTxOCSMT.Application.Run.Config
     )
 import Cardano.UTxOCSMT.Application.Run.Query
     ( mkReadyResponse
+    , queryAwait
     , queryInclusionProof
     , queryMerkleRoots
     , queryUTxOsByAddress
@@ -69,6 +70,7 @@ import ChainFollower.Backend qualified as Backend
 import ChainFollower.Rollbacks.Store qualified as CFStore
 import ChainFollower.Runner (Phase (..))
 import Control.Concurrent.Async (async, link)
+import Control.Concurrent.STM (newTVarIO)
 import Control.Exception (SomeException, catch, displayException)
 import Control.Lens (iso)
 import Control.Monad ((<=<))
@@ -133,6 +135,9 @@ main = withUtf8 $ do
 
         -- IORef for sharing metrics with HTTP (via shareTracer pattern)
         metricsRef <- newIORef Nothing
+
+        -- Commit notification TVar for awaitValue
+        commitNotify <- newTVarIO (0 :: Int)
 
         -- Break the circular dependency:
         -- metricsEvent needs mainTracer (to inject MetricsReport)
@@ -224,6 +229,7 @@ main = withUtf8 $ do
                         (queryInclusionProof runner)
                         (queryUTxOsByAddress runner)
                         getReadyResponse
+                        (queryAwait commitNotify runner)
 
             SetupResult
                 { setupStartingPoint
@@ -297,6 +303,7 @@ main = withUtf8 $ do
                             backendInit
                             armageddonParams
                             (fromIntegral setupSecurityParam)
+                            commitNotify
                             initialPhase
                             availablePoints
                     N2C{n2cSocket} ->
@@ -312,6 +319,7 @@ main = withUtf8 $ do
                             backendInit
                             armageddonParams
                             (fromIntegral setupSecurityParam)
+                            commitNotify
                             initialPhase
                             availablePoints
                 )

--- a/application/Cardano/UTxOCSMT/Application/Run/Query.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Query.hs
@@ -3,6 +3,8 @@ module Cardano.UTxOCSMT.Application.Run.Query
     , queryInclusionProof
     , queryUTxOsByAddress
     , mkReadyResponse
+    , queryAwaitValue
+    , queryAwait
     )
 where
 
@@ -46,7 +48,8 @@ import Cardano.UTxOCSMT.Application.Run.Config
     )
 import Cardano.UTxOCSMT.Application.UTxOs (unsafeMkTxIn)
 import Cardano.UTxOCSMT.HTTP.API
-    ( InclusionProofResponse (..)
+    ( AwaitResponse (..)
+    , InclusionProofResponse (..)
     , MerkleRootEntry (..)
     , ReadyResponse (..)
     , UTxOByAddressEntry (..)
@@ -57,6 +60,14 @@ import Cardano.UTxOCSMT.HTTP.Base16
     , unsafeDecodeBase16Text
     )
 import Cardano.UTxOCSMT.Ouroboros.Types (Header, Point)
+import Control.Concurrent.STM
+    ( TVar
+    , atomically
+    , readTVar
+    , readTVarIO
+    , retry
+    )
+import Control.Monad (when)
 import Data.ByteArray.Encoding
     ( Base (..)
     , convertToBase
@@ -67,10 +78,12 @@ import Data.ByteString.Short (toShort)
 import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
 import Data.Word (Word16, Word64)
+import Database.KV.Transaction (query)
 import Database.RocksDB (BatchOp, ColumnFamily)
 import Ouroboros.Network.Block (SlotNo (..))
 import Ouroboros.Network.Block qualified as Network
 import Ouroboros.Network.Point (Block (..), WithOrigin (..))
+import System.Timeout (timeout)
 
 {- | Query all merkle roots from the database.
 
@@ -229,3 +242,64 @@ mkReadyResponse threshold mMetrics =
     getProcessedSlot Nothing = Nothing
     getProcessedSlot (Just (_, header)) =
         Just $ unSlotNo $ Network.blockSlot header
+
+{- | Block until a key appears in the store or timeout expires.
+
+Uses a TVar counter that is incremented after each commit.
+The STM runtime wakes blocked threads when the counter changes,
+at which point we re-check the store for the key.
+-}
+queryAwaitValue
+    :: TVar Int
+    -- ^ Commit notification counter
+    -> (key -> IO (Maybe value))
+    -- ^ getValue function
+    -> key
+    -- ^ Key to wait for
+    -> Maybe Int
+    -- ^ Timeout in seconds (Nothing = 30s default)
+    -> IO (Maybe value)
+queryAwaitValue notifyTVar getValue' key mTimeout = do
+    let timeoutMicros = maybe 30_000_000 (* 1_000_000) mTimeout
+    timeout timeoutMicros $ do
+        let go lastSeen = do
+                mval <- getValue' key
+                case mval of
+                    Just v -> pure v
+                    Nothing -> do
+                        atomically $ do
+                            current <- readTVar notifyTVar
+                            when (current == lastSeen) retry
+                        go =<< readTVarIO notifyTVar
+        go =<< readTVarIO notifyTVar
+
+{- | HTTP await handler: block until a UTxO appears, returning
+an AwaitResponse with the base16-encoded TxOut.
+-}
+queryAwait
+    :: TVar Int
+    -> RunTransaction
+        ColumnFamily
+        BatchOp
+        Point
+        Hash
+        LazyByteString
+        LazyByteString
+        IO
+    -> Text
+    -> Word16
+    -> Maybe Int
+    -> IO (Maybe AwaitResponse)
+queryAwait notifyTVar (RunTransaction runTx) txIdText txIx mTimeout = do
+    let txIn = unsafeMkTxIn (toShort $ unsafeDecodeBase16Text txIdText) txIx
+        getValue' k = runTx $ query KVCol k
+    mval <- queryAwaitValue notifyTVar getValue' txIn mTimeout
+    pure
+        $ fmap
+            ( \out ->
+                AwaitResponse
+                    txIdText
+                    txIx
+                    (encodeBase16Text $ toStrict out)
+            )
+            mval

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -44,6 +44,7 @@ common warnings
     LambdaCase
     MultiParamTypeClasses
     NamedFieldPuns
+    NumericUnderscores
     OverloadedStrings
     PatternSynonyms
     RankNTypes
@@ -145,6 +146,7 @@ library application
     , ouroboros-network-api
     , rocksdb-haskell-jprupp
     , rocksdb-kv-transactions:kv-transactions
+    , stm
     , strict-stm
     , text
     , time
@@ -293,6 +295,7 @@ test-suite unit-tests
   hs-source-dirs:     test
   build-depends:
     , aeson
+    , async
     , base                           <5
     , bytestring
     , cardano-crypto-class
@@ -312,6 +315,7 @@ test-suite unit-tests
     , opt-env-conf
     , ouroboros-network-api
     , QuickCheck
+    , stm
     , text
     , time
     , yaml
@@ -324,6 +328,7 @@ test-suite unit-tests
     Cardano.UTxOCSMT.Application.Database.InterfaceSpec
     Cardano.UTxOCSMT.Application.Metrics.TypesSpec
     Cardano.UTxOCSMT.Application.OptionsSpec
+    Cardano.UTxOCSMT.Application.Run.QuerySpec
     Cardano.UTxOCSMT.Application.UTxOsSpec
     Cardano.UTxOCSMT.HTTP.Base16Spec
     Control.Foldl.ExtraSpec
@@ -442,6 +447,7 @@ test-suite e2e-tests
     , process
     , rocksdb-haskell-jprupp
     , rocksdb-kv-transactions:kv-transactions
+    , stm
     , temporary
     , time
     , unix

--- a/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
+++ b/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
@@ -485,7 +485,7 @@ session
     -> IO ReadyResponse
     -> Session b
     -> IO b
-session a b c d e = flip runSession $ apiApp a b c d e
+session a b c d e = flip runSession $ apiApp a b c d e (\_ _ _ -> pure Nothing)
 
 spec :: Spec
 spec = do

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -1,5 +1,27 @@
 {
     "definitions": {
+        "AwaitResponse": {
+            "description": "Response after awaiting a UTxO to appear in the CSMT",
+            "properties": {
+                "txId": {
+                    "type": "string"
+                },
+                "txIx": {
+                    "maximum": 65535,
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "txOut": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "txId",
+                "txIx",
+                "txOut"
+            ],
+            "type": "object"
+        },
         "InclusionProofResponse": {
             "description": "Current inclusion proof and output for the given transaction input.",
             "properties": {
@@ -261,6 +283,48 @@
         "version": "0.1.0.0"
     },
     "paths": {
+        "/await/{txId}/{txIx}": {
+            "get": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "txId",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "maximum": 65535,
+                        "minimum": 0,
+                        "name": "txIx",
+                        "required": true,
+                        "type": "integer"
+                    },
+                    {
+                        "in": "query",
+                        "maximum": 9223372036854775807,
+                        "minimum": -9223372036854775808,
+                        "name": "timeout",
+                        "required": false,
+                        "type": "integer"
+                    }
+                ],
+                "produces": [
+                    "application/json;charset=utf-8"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/AwaitResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid `timeout` or `txIx` or `txId`"
+                    }
+                }
+            }
+        },
         "/merkle-roots": {
             "get": {
                 "produces": [

--- a/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
+++ b/e2e-test/Cardano/UTxOCSMT/E2E/GenesisChainSyncSpec.hs
@@ -48,6 +48,7 @@ import Cardano.UTxOCSMT.Application.Run.Setup
 import ChainFollower.Backend qualified as Backend
 import ChainFollower.Rollbacks.Store qualified as CFStore
 import ChainFollower.Runner (Phase (..))
+import Control.Concurrent.STM (newTVarIO)
 import Control.Lens (iso)
 import Control.Tracer (nullTracer)
 import Data.ByteString.Lazy qualified as BL
@@ -154,6 +155,7 @@ spec = describe "Genesis chain sync" $ do
                                             InFollowing
                                                 initialCount
                                                 following
+                                    notifyTVar <- newTVarIO (0 :: Int)
                                     result <-
                                         timeout
                                             15_000_000
@@ -171,6 +173,7 @@ spec = describe "Genesis chain sync" $ do
                                                 backendInit
                                                 armageddonParams
                                                 maxBound
+                                                notifyTVar
                                                 initialPhase
                                                 [setupStartingPoint]
                                     result

--- a/http/Cardano/UTxOCSMT/HTTP/API.hs
+++ b/http/Cardano/UTxOCSMT/HTTP/API.hs
@@ -22,6 +22,7 @@ module Cardano.UTxOCSMT.HTTP.API
     , InclusionProofResponse (..)
     , UTxOByAddressEntry (..)
     , ReadyResponse (..)
+    , AwaitResponse (..)
     )
 where
 
@@ -51,6 +52,7 @@ import Servant
     , Get
     , JSON
     , PlainText
+    , QueryParam
     , type (:<|>)
     , type (:>)
     )
@@ -81,6 +83,11 @@ type API =
             :> Get '[JSON] [UTxOByAddressEntry]
         :<|> "ready"
             :> Get '[JSON] ReadyResponse
+        :<|> "await"
+            :> Capture "txId" Text
+            :> Capture "txIx" Word16
+            :> QueryParam "timeout" Int
+            :> Get '[JSON] AwaitResponse
 
 -- | Proxy for the API
 api :: Proxy API
@@ -276,3 +283,47 @@ instance ToSchema ReadyResponse where
             & required .~ ["ready", "tipSlot", "processedSlot", "slotsBehind"]
             & description
                 ?~ "Sync readiness status for orchestration"
+
+-- | Response for the /await endpoint
+data AwaitResponse = AwaitResponse
+    { awaitTxId :: Text
+    -- ^ Transaction ID that was awaited
+    , awaitTxIx :: Word16
+    -- ^ Transaction index
+    , awaitTxOut :: Text
+    -- ^ CBOR-encoded TxOut in base16
+    }
+    deriving (Show, Eq)
+
+instance ToJSON AwaitResponse where
+    toJSON AwaitResponse{awaitTxId, awaitTxIx, awaitTxOut} =
+        object
+            [ "txId" .= awaitTxId
+            , "txIx" .= awaitTxIx
+            , "txOut" .= awaitTxOut
+            ]
+
+instance FromJSON AwaitResponse where
+    parseJSON = withObject "AwaitResponse" $ \v ->
+        AwaitResponse
+            <$> v .: "txId"
+            <*> v .: "txIx"
+            <*> v .: "txOut"
+
+instance ToSchema AwaitResponse where
+    declareNamedSchema _ = do
+        stringSchema <- declareSchemaRef (Proxy @String)
+        word16Schema <- declareSchemaRef (Proxy @Word16)
+        return
+            $ Swagger.NamedSchema (Just "AwaitResponse")
+            $ mempty
+            & Swagger.type_ ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("txId", stringSchema)
+                    , ("txIx", word16Schema)
+                    , ("txOut", stringSchema)
+                    ]
+            & required .~ ["txId", "txIx", "txOut"]
+            & description
+                ?~ "Response after awaiting a UTxO to appear in the CSMT"

--- a/http/Cardano/UTxOCSMT/HTTP/Server.hs
+++ b/http/Cardano/UTxOCSMT/HTTP/Server.hs
@@ -12,6 +12,7 @@ import Cardano.UTxOCSMT.Application.Metrics
     )
 import Cardano.UTxOCSMT.HTTP.API
     ( API
+    , AwaitResponse
     , InclusionProofResponse
     , MerkleRootEntry
     , ReadyResponse (..)
@@ -34,6 +35,7 @@ import Network.Wai.Middleware.Cors (simpleCors)
 import Servant
     ( Handler
     , Server
+    , ServerError (..)
     , err400
     , err404
     , err503
@@ -50,14 +52,16 @@ apiServer
     -> (Text -> Word16 -> IO (Maybe InclusionProofResponse))
     -> (Text -> IO (Either String [UTxOByAddressEntry]))
     -> IO ReadyResponse
+    -> (Text -> Word16 -> Maybe Int -> IO (Maybe AwaitResponse))
     -> Server API
-apiServer getMetrics getMerkleRoots getProof getByAddress getReady =
+apiServer getMetrics getMerkleRoots getProof getByAddress getReady getAwait =
     prometheusHandler
         :<|> metricsHandler
         :<|> merkleRootsHandler
         :<|> proofHandler
         :<|> byAddressHandler
         :<|> readyHandler
+        :<|> awaitHandler
   where
     metricsHandler = do
         r <- liftIO getMetrics
@@ -93,6 +97,23 @@ apiServer getMetrics getMerkleRoots getProof getByAddress getReady =
 
     readyHandler = liftIO getReady
 
+    awaitHandler txId txIx mTimeout = do
+        r <- liftIO $ getAwait txId txIx mTimeout
+        maybe
+            (throwError err408)
+            pure
+            r
+
+-- | HTTP 408 Request Timeout
+err408 :: ServerError
+err408 =
+    ServerError
+        { errHTTPCode = 408
+        , errReasonPhrase = "Request Timeout"
+        , errBody = "Timeout waiting for UTxO to appear"
+        , errHeaders = []
+        }
+
 -- | WAI Application for the API
 apiApp
     :: IO (Maybe Metrics)
@@ -100,11 +121,18 @@ apiApp
     -> (Text -> Word16 -> IO (Maybe InclusionProofResponse))
     -> (Text -> IO (Either String [UTxOByAddressEntry]))
     -> IO ReadyResponse
+    -> (Text -> Word16 -> Maybe Int -> IO (Maybe AwaitResponse))
     -> Application
-apiApp getMetrics getMerkleRoots getProof getByAddress getReady =
+apiApp getMetrics getMerkleRoots getProof getByAddress getReady getAwait =
     simpleCors
         $ serve api
-        $ apiServer getMetrics getMerkleRoots getProof getByAddress getReady
+        $ apiServer
+            getMetrics
+            getMerkleRoots
+            getProof
+            getByAddress
+            getReady
+            getAwait
 
 {- | Run the API server on the specified port
 Takes a port number, an IO action that provides the current Metrics,
@@ -119,10 +147,17 @@ runAPIServer
     -> (Text -> Word16 -> IO (Maybe InclusionProofResponse))
     -> (Text -> IO (Either String [UTxOByAddressEntry]))
     -> IO ReadyResponse
+    -> (Text -> Word16 -> Maybe Int -> IO (Maybe AwaitResponse))
     -> IO ()
-runAPIServer port getMetrics getMerkleRoots getProof getByAddress getReady =
+runAPIServer port getMetrics getMerkleRoots getProof getByAddress getReady getAwait =
     run (fromIntegral port)
-        $ apiApp getMetrics getMerkleRoots getProof getByAddress getReady
+        $ apiApp
+            getMetrics
+            getMerkleRoots
+            getProof
+            getByAddress
+            getReady
+            getAwait
 
 -- | WAI Application for the documentation
 docsApp :: Maybe PortNumber -> Application

--- a/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs
@@ -96,6 +96,7 @@ mkQuery isoK =
                         $ addressBytes
             indirects <- collectValues CSMTCol [] addressKey
             catMaybes <$> traverse lookupKV indirects
+        , awaitValue = \k _timeout -> query KVCol k
         }
   where
     lookupKV indirect = do

--- a/lib/Cardano/UTxOCSMT/Application/Database/Interface.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Interface.hs
@@ -95,6 +95,10 @@ data Query m slot key value = Query
     -- ^ Get the finality slot (immutable point)
     , getByAddress :: ByteString -> m [(key, value)]
     -- ^ Get all UTxOs at a given address (raw address bytes)
+    , awaitValue :: key -> Maybe Int -> m (Maybe value)
+    {- ^ Block until a key appears or timeout (seconds) expires.
+    Uses STM retry on a commit notification TVar.
+    -}
     }
 
 -- | Let a transaction runner apply to all queries
@@ -102,12 +106,13 @@ hoistQuery
     :: (forall a. m a -> n a)
     -> Query m slot key value
     -> Query n slot key value
-hoistQuery nat Query{getValue, getTip, getFinality, getByAddress} =
+hoistQuery nat Query{getValue, getTip, getFinality, getByAddress, awaitValue} =
     Query
         { getValue = nat . getValue
         , getTip = nat getTip
         , getFinality = nat getFinality
         , getByAddress = nat . getByAddress
+        , awaitValue = \k t -> nat (awaitValue k t)
         }
 
 {- | Get the inverse of an operation, needs access to the database to retrieve

--- a/specs/002-await-value/checklists/requirements.md
+++ b/specs/002-await-value/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Await Value
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.

--- a/specs/002-await-value/data-model.md
+++ b/specs/002-await-value/data-model.md
@@ -1,0 +1,71 @@
+# Data Model: Push-based UTxO Await
+
+## New Entities
+
+### CommitNotification
+
+A `TVar Int` counter incremented after each successful `processBlock` commit.
+
+- Created at application startup (Main.hs)
+- Written by: Application chain sync loop (after each commit)
+- Read by: Query.awaitValue (STM retry on counter change)
+
+### awaitValue (Query field)
+
+```
+awaitValue :: key -> Maybe Int -> m (Maybe value)
+```
+
+- `key`: the UTxO key to wait for
+- `Maybe Int`: optional timeout in seconds (Nothing = server default)
+- Returns `Just value` if found, `Nothing` on timeout
+
+### HTTP Endpoint
+
+```
+GET /await/:txId/:txIx?timeout=30
+```
+
+- Path parameters: transaction ID and index (same format as /proof/:txId/:txIx)
+- Query parameter: timeout in seconds (default: 30, max: 120)
+- Response 200: value found (same format as existing UTxO responses)
+- Response 408: timeout expired
+
+## State Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant HTTP as HTTP Handler
+    participant Await as awaitValue
+    participant Store as RocksDB
+    participant App as Application
+    participant TVar as TVar Int
+
+    Client->>HTTP: GET /await/txId/txIx timeout=30
+    HTTP->>Await: awaitValue(key, Just 30)
+    Await->>Store: getValue(key)
+    alt Key exists (fast path)
+        Store-->>Await: Just value
+        Await-->>HTTP: Just value
+        HTTP-->>Client: 200 OK
+    else Key not found
+        Store-->>Await: Nothing
+        loop STM retry until timeout
+            Await->>TVar: readTVar (blocks via STM retry)
+            App->>Store: processBlock commit
+            App->>TVar: modifyTVar (+1)
+            TVar-->>Await: counter changed, wake up
+            Await->>Store: getValue(key)
+            alt Found
+                Store-->>Await: Just value
+                Await-->>HTTP: Just value
+                HTTP-->>Client: 200 OK
+            else Still not found
+                Store-->>Await: Nothing
+            end
+        end
+        Await-->>HTTP: Nothing (timeout)
+        HTTP-->>Client: 408 Timeout
+    end
+```

--- a/specs/002-await-value/plan.md
+++ b/specs/002-await-value/plan.md
@@ -1,0 +1,70 @@
+# Implementation Plan: Push-based UTxO Await
+
+**Branch**: `002-await-value` | **Date**: 2026-03-27 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Add a TVar-based notification mechanism so clients can block-wait for a key to appear in the UTxO set instead of polling. A single `TVar Int` counter is incremented after each commit; `awaitValue` uses STM retry to block until the counter changes, then re-checks the key.
+
+## Technical Context
+
+**Language/Version**: Haskell (GHC 9.8.4)
+**Primary Dependencies**: `stm` (TVar, STM), `servant-server` (HTTP API), `rocksdb-kv-transactions`
+**Storage**: RocksDB — `getValue` already exists, `awaitValue` wraps it with STM blocking
+**Testing**: HSpec (unit-tests for STM logic, database-tests for integration)
+**Target Platform**: Linux (NixOS)
+**Project Type**: Library + HTTP service
+**Constraints**: Must not break existing Query consumers; coarse-grained notification (no per-key TVars)
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| Pure core / impure shell | Pass | TVar is IO-layer; Query interface gains an IO operation |
+| Correctness | Pass | STM retry guarantees no missed notifications |
+| Small focused commits | Pass | Can split: notification mechanism, Query extension, HTTP endpoint |
+| Test separation | Pass | Unit test for STM logic, database-test for integration |
+| Nix-first | Pass | `stm` is already a dependency |
+
+No violations.
+
+## Project Structure
+
+### Affected Files
+
+```text
+lib/Cardano/UTxOCSMT/Application/Database/Interface.hs
+    — Add awaitValue to Query type
+
+application/Cardano/UTxOCSMT/Application/Run/Application.hs
+    — Increment TVar after each processBlock commit
+
+application/Cardano/UTxOCSMT/Application/Run/Main.hs
+    — Create TVar at startup, thread to Application and HTTP server
+
+application/Cardano/UTxOCSMT/Application/Run/Query.hs
+    — Implement awaitValue handler wrapping getValue + STM retry
+
+http/Cardano/UTxOCSMT/HTTP/API.hs
+    — Add GET /await/:txId/:txIx endpoint to Servant API
+
+http/Cardano/UTxOCSMT/HTTP/Server.hs
+    — Add handler for await endpoint
+
+test/ or database-test/
+    — Tests for await mechanism
+```
+
+### Architecture
+
+```mermaid
+flowchart TD
+    TVar["TVar Int<br>created at startup"]
+    App["Application<br>writer<br>increment +1 after commit"]
+    Query["Query<br>reader<br>STM retry on counter change"]
+    HTTP["HTTP<br>handler<br>calls awaitValue with timeout"]
+
+    TVar --> App
+    TVar --> Query
+    TVar --> HTTP
+```

--- a/specs/002-await-value/research.md
+++ b/specs/002-await-value/research.md
@@ -1,0 +1,57 @@
+# Research: Push-based UTxO Await
+
+## Decision 1: Notification Granularity
+
+**Decision**: Single `TVar Int` counter for all commits (coarse-grained).
+
+**Rationale**: Per-key TVars would require a concurrent map that grows unboundedly. A single counter is simple, efficient, and sufficient — waiters re-check their specific key after each notification. The re-check is a single RocksDB point lookup (microseconds).
+
+**Alternatives considered**:
+- Per-key TVar map — rejected: unbounded memory, cleanup complexity, no meaningful latency improvement since RocksDB lookups are fast.
+- `TChan` broadcast — rejected: requires each waiter to create a channel and risks missed messages if the channel isn't set up before the commit.
+
+## How STM Retry Wakes Waiters
+
+The notification works via the STM runtime's built-in dependency tracking, not explicit signaling:
+
+1. **Waiter** runs `atomically $ do { c <- readTVar tvar; when (c == lastSeen) retry }`. The `retry` tells the STM runtime: "park this thread and record that it read `tvar`."
+2. **Writer** runs `atomically $ modifyTVar' tvar (+1)`. When this commits, the STM runtime detects that `tvar` changed and wakes all threads whose retried transaction read it.
+3. **Woken waiter** re-runs its transaction: reads `tvar` (new value), `c /= lastSeen` so transaction succeeds, thread exits `atomically` and does IO (re-checks RocksDB for the key).
+
+No explicit signals, no condition variables, no missed wakeups. The STM runtime guarantees that any thread blocked on `retry` is woken when any TVar in its read-set changes.
+
+**Concurrency under load**: every commit wakes all waiters (thundering herd), but each waiter does a single RocksDB point lookup (microseconds) then goes back to sleep if its key wasn't in that block. This is acceptable for the expected load (handful of concurrent awaiters).
+
+## Decision 2: Timeout Mechanism
+
+**Decision**: `System.Timeout.timeout` wrapping the STM retry loop.
+
+**Rationale**: Standard library, composable, well-understood. The STM loop retries on TVar changes; timeout kills the thread after the deadline.
+
+**Alternatives considered**:
+- Manual `registerDelay` + STM — more control but unnecessary complexity for this use case.
+
+## Decision 3: HTTP Endpoint Style
+
+**Decision**: Long-poll GET endpoint with timeout query parameter.
+
+**Rationale**: Simplest for clients — standard HTTP GET, no WebSocket complexity. The server holds the connection open until the key appears or timeout expires. Compatible with any HTTP client.
+
+**Alternatives considered**:
+- WebSocket — rejected: overkill for single-value await; adds client-side complexity.
+- Server-Sent Events — rejected: similar complexity to WebSocket for a one-shot use case.
+
+## Decision 4: Where to Increment TVar
+
+**Decision**: In `Application.hs` after the `transact $ processBlock` call.
+
+**Rationale**: This is the exact point where a commit is finalized. The existing code already has the transaction boundary here. Adding `atomically $ modifyTVar' notificationTVar (+1)` after the commit is minimal and correct.
+
+## Decision 5: Query Interface Extension
+
+**Decision**: Add `awaitValue` as a new field in the `Query` record, not a separate type.
+
+**Rationale**: Keeps the Query interface cohesive. Existing consumers are unaffected (they don't use the new field). The field is `Maybe` or the Query constructor is extended with a default.
+
+**Alternative considered**:
+- Separate `AwaitQuery` type — rejected: fragmenting the query interface makes wiring harder.

--- a/specs/002-await-value/spec.md
+++ b/specs/002-await-value/spec.md
@@ -1,0 +1,80 @@
+# Feature Specification: Push-based UTxO Await via TVar Notification
+
+**Feature Branch**: `002-await-value`
+**Created**: 2026-03-27
+**Status**: Draft
+**Input**: Add a blocking `awaitValue` operation that waits for a key to appear in the UTxO set, using TVar-based notification instead of polling.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Await Transaction Indexing (Priority: P1)
+
+After submitting a Cardano transaction, a downstream service (MPFS offchain) needs to confirm the transaction has been indexed in the CSMT before proceeding. Instead of polling `getValue` every second, it calls `awaitValue` which blocks until the key appears or a timeout expires.
+
+**Why this priority**: This is the core use case — replacing the 1-second polling loop with near-instant push notification. Reduces latency from up to 1 second to near-zero.
+
+**Independent Test**: Submit a key via `forwardTipApply`, then verify `awaitValue` returns immediately if the key already exists. In a separate thread, call `awaitValue` for a key that doesn't exist yet, then insert it via `forwardTipApply`, and verify the blocked thread unblocks and returns the value.
+
+**Acceptance Scenarios**:
+
+1. **Given** a key exists in the UTxO set, **When** `awaitValue` is called for that key, **Then** it returns the value immediately.
+2. **Given** a key does not exist, **When** `awaitValue` is called and then the key is inserted via a chain update, **Then** `awaitValue` unblocks and returns the value.
+3. **Given** a key does not exist and a timeout is specified, **When** the timeout expires before the key appears, **Then** `awaitValue` returns `Nothing`.
+
+---
+
+### User Story 2 - HTTP Await Endpoint (Priority: P2)
+
+An HTTP endpoint exposes the await functionality so external services can block-wait for a transaction to be indexed without implementing their own polling loop.
+
+**Why this priority**: The MPFS offchain service currently polls via HTTP. An HTTP await endpoint eliminates the polling entirely at the API boundary.
+
+**Independent Test**: Make an HTTP request to the await endpoint for a non-existent key, insert the key via chain update in another thread, verify the HTTP response arrives with the value.
+
+**Acceptance Scenarios**:
+
+1. **Given** a key exists, **When** `GET /await/:txId/:txIx` is called, **Then** it returns 200 with the value immediately.
+2. **Given** a key does not exist, **When** the endpoint is called and the key is inserted before timeout, **Then** it returns 200 with the value.
+3. **Given** a key does not exist and the timeout expires, **When** the endpoint is called, **Then** it returns 408 Request Timeout.
+
+---
+
+### Edge Cases
+
+- Multiple clients awaiting the same key: all should be notified when the key appears.
+- Key appears then disappears (rollback): the await should return the value at the time of notification; subsequent rollbacks are a separate concern.
+- Server shutdown while clients are waiting: blocked threads should be interrupted cleanly.
+- Very high frequency of commits: notification should not cause thundering herd — clients re-check their specific key, not scan the whole store.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `Query` interface MUST provide an `awaitValue :: key -> m (Maybe value)` operation that blocks until the key exists or a timeout expires.
+- **FR-002**: The database update path MUST broadcast a notification after each successful `forwardTipApply` commit.
+- **FR-003**: The notification mechanism MUST use STM (`TVar`) so that multiple waiting threads are woken efficiently.
+- **FR-004**: `awaitValue` MUST check the store immediately (fast path) before blocking.
+- **FR-005**: The HTTP API MUST expose an await endpoint with a configurable timeout.
+- **FR-006**: The timeout MUST be configurable per-request (query parameter or header) with a server-side maximum.
+
+### Key Entities
+
+- **Notification TVar**: A counter or epoch incremented after each commit. Waiters retry their lookup when the counter changes.
+- **Query (extended)**: Adds `awaitValue` alongside existing `getValue`.
+- **HTTP Await Endpoint**: Long-poll GET endpoint that blocks until the key appears or timeout.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `awaitValue` returns within 100ms of the key being committed (vs up to 1 second with polling).
+- **SC-002**: No CPU usage while waiting (STM retry, not busy-loop).
+- **SC-003**: Multiple concurrent awaiters for different keys do not interfere with each other.
+- **SC-004**: The HTTP await endpoint handles at least 100 concurrent waiting connections without degradation.
+
+## Assumptions
+
+- The notification mechanism is coarse-grained: a single TVar counter for all commits, not per-key notifications. Waiters re-check their specific key after each notification.
+- The timeout is enforced via `System.Timeout.timeout` wrapping the STM retry loop.
+- The HTTP endpoint uses standard Servant handler with `liftIO` for the blocking operation.
+- The TVar is created at application startup and threaded through the Query/Update interfaces.

--- a/specs/002-await-value/tasks.md
+++ b/specs/002-await-value/tasks.md
@@ -1,0 +1,101 @@
+# Tasks: Push-based UTxO Await
+
+**Input**: Design documents from `/specs/002-await-value/`
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+
+## Phase 1: Foundational — Notification Mechanism
+
+**Purpose**: Create the TVar notification plumbing without changing any external interfaces.
+
+- [ ] T001 [US1] Add `awaitValue` field to `Query` record in `lib/Cardano/UTxOCSMT/Application/Database/Interface.hs`
+- [ ] T002 [US1] Update `hoistQuery` to transform the new `awaitValue` field in `lib/Cardano/UTxOCSMT/Application/Database/Interface.hs`
+- [ ] T003 [US1] Add `TVar Int` parameter to `application` function and increment after each `processBlock` commit in `application/Cardano/UTxOCSMT/Application/Run/Application.hs`
+
+**Checkpoint**: Query type extended, notification fires after commits. Existing code compiles with placeholder `awaitValue`.
+
+---
+
+## Phase 2: User Story 1 — awaitValue Implementation (Priority: P1)
+
+**Goal**: `awaitValue` blocks until a key appears in the store, using STM retry on the notification TVar.
+
+**Independent Test**: In two threads — one calls awaitValue, the other inserts a key. The blocked thread unblocks and returns the value.
+
+### Implementation
+
+- [ ] T004 [US1] Implement `queryAwaitValue` handler using STM retry loop + `System.Timeout.timeout` in `application/Cardano/UTxOCSMT/Application/Run/Query.hs`
+- [ ] T005 [US1] Create `TVar Int` at startup in `application/Cardano/UTxOCSMT/Application/Run/Main.hs`, pass to `application` and wire into Query
+- [ ] T006 [US1] Update `mkQuery` / `mkTransactionedQuery` to accept notification TVar and populate `awaitValue` field in `lib/Cardano/UTxOCSMT/Application/Database/Implementation/Query.hs`
+
+**Checkpoint**: `awaitValue` works end-to-end in the application. Can be tested programmatically.
+
+---
+
+## Phase 3: User Story 2 — HTTP Await Endpoint (Priority: P2)
+
+**Goal**: External clients can block-wait for a UTxO key via HTTP.
+
+**Independent Test**: HTTP request to `/await/:txId/:txIx` blocks until key is inserted, returns 200 with value.
+
+### Implementation
+
+- [ ] T007 [US2] Add `GET /await/:txId/:txIx` endpoint with `timeout` query parameter to Servant API type in `http/Cardano/UTxOCSMT/HTTP/API.hs`
+- [ ] T008 [US2] Add `AwaitResponse` type (or reuse existing proof/UTxO response) in `http/Cardano/UTxOCSMT/HTTP/API.hs`
+- [ ] T009 [US2] Implement HTTP handler that calls `awaitValue` and returns 200 or 408 in `http/Cardano/UTxOCSMT/HTTP/Server.hs`
+- [ ] T010 [US2] Wire await handler into server and pass Query with awaitValue to HTTP layer in `application/Cardano/UTxOCSMT/Application/Run/Query.hs`
+
+**Checkpoint**: HTTP await endpoint works end-to-end.
+
+---
+
+## Phase 4: Tests
+
+- [ ] T011 [P] [US1] Add unit test for awaitValue STM logic: fast path (key exists), slow path (key inserted after await), timeout in `test/`
+- [ ] T012 [P] [US1] Add database-test for awaitValue with real RocksDB: insert key in one thread, await in another in `database-test/`
+
+**Checkpoint**: All tests pass.
+
+---
+
+## Phase 5: Polish
+
+- [ ] T013 Update Swagger documentation (`just update-swagger`)
+- [ ] T014 Run `just format`, `just hlint`, `just cabal-check`
+- [ ] T015 Build and run all test suites
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1** (T001-T003): Sequential — T001 first (type change), then T002-T003
+- **Phase 2** (T004-T006): Depends on Phase 1. T004 and T006 can be parallel, T005 wires them.
+- **Phase 3** (T007-T010): Depends on Phase 2. T007-T008 parallel, T009 after, T010 after.
+- **Phase 4** (T011-T012): Depends on Phase 2 (US1 tests) and Phase 3 (US2 would need HTTP tests too). T011 and T012 parallel.
+- **Phase 5** (T013-T015): Depends on all above.
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phase 1: notification plumbing
+2. Phase 2: awaitValue in Query interface
+3. Phase 4 (T011-T012): tests for US1
+4. Deploy — MPFS can use awaitValue programmatically
+
+### Full Feature
+
+5. Phase 3: HTTP endpoint
+6. Phase 5: polish
+
+---
+
+## Notes
+
+- 15 tasks across 5 phases
+- 2 user stories: P1 (programmatic await), P2 (HTTP endpoint)
+- MVP delivers programmatic await; HTTP endpoint is additive
+- Commits: split by phase (notification mechanism, await impl, HTTP endpoint, tests)

--- a/test/Cardano/UTxOCSMT/Application/Database/InterfaceSpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Database/InterfaceSpec.hs
@@ -51,6 +51,7 @@ spec = describe "Database.Interface" $ do
                             , getTip = Identity Sentinel
                             , getFinality = Identity Sentinel
                             , getByAddress = \_ -> Identity []
+                            , awaitValue = \_ _ -> Identity Nothing
                             }
                     q' = hoistQuery id q
                 in  runIdentity (getValue q' ()) `shouldBe` Just bs
@@ -62,6 +63,7 @@ spec = describe "Database.Interface" $ do
                         , getTip = Identity (Value (42 :: Int))
                         , getFinality = Identity Sentinel
                         , getByAddress = \_ -> Identity []
+                        , awaitValue = \_ _ -> Identity Nothing
                         }
                 q' = hoistQuery id q
             runIdentity (getTip q') `shouldBe` Value 42

--- a/test/Cardano/UTxOCSMT/Application/Run/QuerySpec.hs
+++ b/test/Cardano/UTxOCSMT/Application/Run/QuerySpec.hs
@@ -1,0 +1,100 @@
+module Cardano.UTxOCSMT.Application.Run.QuerySpec (spec) where
+
+import Cardano.UTxOCSMT.Application.Run.Query (queryAwaitValue)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (async, wait)
+import Control.Concurrent.STM
+    ( TVar
+    , atomically
+    , modifyTVar'
+    , newTVarIO
+    )
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+
+-- | Mutable store backed by IORef for testing
+newtype TestStore = TestStore (IORef [(String, String)])
+
+mkStore :: IO TestStore
+mkStore = TestStore <$> newIORef []
+
+insertKey :: TestStore -> String -> String -> IO ()
+insertKey (TestStore ref) k v = modifyIORef' ref ((k, v) :)
+
+lookupKey :: TestStore -> String -> IO (Maybe String)
+lookupKey (TestStore ref) k = lookup k <$> readIORef ref
+
+-- | Simulate a commit by incrementing the TVar
+notify :: TVar Int -> IO ()
+notify tvar = atomically $ modifyTVar' tvar (+ 1)
+
+spec :: Spec
+spec = describe "queryAwaitValue" $ do
+    it "returns immediately when key already exists" $ do
+        store <- mkStore
+        tvar <- newTVarIO (0 :: Int)
+        insertKey store "tx1" "output1"
+        result <- queryAwaitValue tvar (lookupKey store) "tx1" (Just 1)
+        result `shouldBe` Just "output1"
+
+    it "blocks until key is inserted then returns value" $ do
+        store <- mkStore
+        tvar <- newTVarIO (0 :: Int)
+        -- Start awaiting in a separate thread
+        awaiter <-
+            async $ queryAwaitValue tvar (lookupKey store) "tx2" (Just 5)
+        -- Give the awaiter time to enter the retry loop
+        threadDelay 100_000
+        -- Insert the key and notify
+        insertKey store "tx2" "output2"
+        notify tvar
+        -- The awaiter should unblock and return the value
+        result <- wait awaiter
+        result `shouldBe` Just "output2"
+
+    it "returns Nothing on timeout when key never appears" $ do
+        store <- mkStore
+        tvar <- newTVarIO (0 :: Int)
+        result <- queryAwaitValue tvar (lookupKey store) "tx3" (Just 1)
+        result `shouldBe` Nothing
+
+    it "wakes up on notification but retries if key still missing" $ do
+        store <- mkStore
+        tvar <- newTVarIO (0 :: Int)
+        awaiter <-
+            async $ queryAwaitValue tvar (lookupKey store) "tx4" (Just 5)
+        -- Notify without inserting the key — awaiter should go back to sleep
+        threadDelay 100_000
+        notify tvar
+        threadDelay 100_000
+        -- Now insert and notify — awaiter should wake and find it
+        insertKey store "tx4" "output4"
+        notify tvar
+        result <- wait awaiter
+        result `shouldBe` Just "output4"
+
+    it "multiple awaiters for different keys" $ do
+        store <- mkStore
+        tvar <- newTVarIO (0 :: Int)
+        a1 <- async $ queryAwaitValue tvar (lookupKey store) "txA" (Just 5)
+        a2 <- async $ queryAwaitValue tvar (lookupKey store) "txB" (Just 5)
+        threadDelay 100_000
+        -- Insert txB first
+        insertKey store "txB" "outputB"
+        notify tvar
+        r2 <- wait a2
+        r2 `shouldBe` Just "outputB"
+        -- txA should still be waiting
+        threadDelay 100_000
+        insertKey store "txA" "outputA"
+        notify tvar
+        r1 <- wait a1
+        r1 `shouldBe` Just "outputA"
+
+    it "uses default 30s timeout when Nothing is passed" $ do
+        store <- mkStore
+        tvar <- newTVarIO (0 :: Int)
+        -- Insert immediately so it returns fast
+        insertKey store "tx5" "output5"
+        result <- queryAwaitValue tvar (lookupKey store) "tx5" Nothing
+        result `shouldSatisfy` (== Just "output5")


### PR DESCRIPTION
## Summary
- Add `awaitValue` to `Query` interface — blocks until a key appears or timeout expires
- Add `queryAwaitValue` primitive using STM retry on a `TVar Int` commit counter
- Add `GET /await/:txId/:txIx?timeout=N` HTTP endpoint (returns 200 or 408)
- Add `NumericUnderscores` to default extensions
- Increment TVar after each `processBlock` commit in the chain sync loop

Closes #151