### PR TITLE
fix: SyncPhase from Runner state + slot distance, wire tracing, bump deps

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Application.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Application.hs
@@ -22,7 +22,8 @@ import Cardano.UTxOCSMT.Application.ChainSyncN2C
     ( mkN2CChainSyncApplication
     )
 import Cardano.UTxOCSMT.Application.Database.Backend
-    ( processBlock
+    ( RunnerEvent (..)
+    , processBlock
     , rollbackTo
     )
 import Cardano.UTxOCSMT.Application.Database.Implementation.Armageddon
@@ -62,7 +63,7 @@ import ChainFollower.Runner (Phase (..))
 import Control.Concurrent.STM (TVar, atomically, modifyTVar')
 import Control.Exception (throwIO)
 import Control.Monad (replicateM_)
-import Control.Tracer (Tracer (..))
+import Control.Tracer (Tracer (..), contramap)
 import Data.ByteString.Lazy (ByteString)
 
 import Data.Tracer.TraceWith
@@ -94,6 +95,7 @@ data ApplicationTrace
     | ApplicationIntersectionFailed
     | ApplicationRollingBack Point
     | ApplicationBlockProcessed SlotNo Int Int
+    | ApplicationRunnerEvent (RunnerEvent (WithSentinel Point))
     deriving (Show)
 
 -- | Render an 'ApplicationTrace'
@@ -117,6 +119,16 @@ renderApplicationTrace
             ++ " txs, "
             ++ show utxoCount
             ++ " UTxO changes"
+renderApplicationTrace
+    (ApplicationRunnerEvent event) =
+        "Runner: " ++ case event of
+            BlockRestored slot ->
+                "block restored at " ++ show slot
+            BlockFollowed slot ->
+                "block followed at " ++ show slot
+            PhaseTransition slot ->
+                "PHASE TRANSITION restoration → following at "
+                    ++ show slot
 
 origin :: Network.Point block
 origin = Network.Point{getPoint = Origin}
@@ -273,6 +285,10 @@ follower
                             _ -> pure ()
                         phase' <-
                             processBlock
+                                ( contramap
+                                    ApplicationRunnerEvent
+                                    tracer
+                                )
                                 atTip
                                 transact
                                 Rollbacks

--- a/cabal.project
+++ b/cabal.project
@@ -20,8 +20,8 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/rocksdb-haskell.git
-  tag: a3e86b39f9510fea54abf734ee84aec33d0d683f
-  --sha256: 1gjzqhf81fy3bpc79ndmx3s77x3s1gf0lsk762acbfnpfh6g1hd0
+  tag: 85977e8673f171684bf52ccde437db38bb06c478
+  --sha256: 14idabzvfcz3ll10ha7mm30y0c7m521xvq88q0w71nc0imjwn2h1
 
 source-repository-package
   type: git
@@ -38,8 +38,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/rocksdb-kv-transactions
-  tag: 44c3c2a4b7bab8ca0ca444c99977a358fc6af0ae
-  --sha256: 0rxc1g7imzlapdgab1v6cyy5nrgg8ilwbr9r015dxbdazl5rm9b9
+  tag: e2e77579888ebbd832ea750ebf2635dfc3307025
+  --sha256: 0nd1yz6k3xh1p7nlswp2jbw74bzqr7bvz11kcfyhhimqmjhkqvwm
 
 source-repository-package
   type: git
@@ -56,14 +56,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-node-clients
-  tag: f4cf9f3e68b7ce2ea0a9fcbe0759ecfffdcd3d27
-  --sha256: 0c7dgy3qanc2wd6k6bxz7zi8m5b1wlfh6as7a6v63a08jqnglkcl
+  tag: 73287cdd52cdc973daf760c83da38472c73caa8d
+  --sha256: 1w49mgc6lccks0v6sm1018fj3zpgpg1504v7ypgcmv5js82faf31
 
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/chain-follower
-  tag: 61e9a34181ea7f34daf67463eaf8aeb7414854c0
-  --sha256: 0gc8sq8dwi1g5js8qrcmnka7p19qqviwmgx4iyp43qk56x7n4lap
+  tag: 9db51071e189d72bcd2fce5ab3735a65b7763f9e
+  --sha256: 167j782qqnpymdi14pnakcqdmcj9p6bzk72n7px41pxs3z3w1041
 
 -- Enable iohk flag for contra-tracer-contrib to use CHaP's simple API
 constraints: contra-tracer-contrib +iohk

--- a/database-test/Cardano/UTxOCSMT/Application/Database/E2ERunnerSpec.hs
+++ b/database-test/Cardano/UTxOCSMT/Application/Database/E2ERunnerSpec.hs
@@ -49,6 +49,7 @@ import Codec.CBOR.Read qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
 import Control.Lens (lazy, prism', strict, view)
 import Control.Monad (foldM, foldM_, forM, forM_)
+import Control.Tracer (nullTracer)
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Char8 qualified as BC
 import Data.ByteString.Lazy qualified as BL
@@ -371,6 +372,7 @@ spec = describe "E2E Runner" $ do
         withFreshDB $ \phase transact -> do
             _ <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -387,6 +389,7 @@ spec = describe "E2E Runner" $ do
             -- Forward slot 1
             phase1 <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -401,6 +404,7 @@ spec = describe "E2E Runner" $ do
                 val2 = mkTestValue "output2"
             phase2 <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -438,6 +442,7 @@ spec = describe "E2E Runner" $ do
                 -- Slot 1: insert two
                 phase1 <-
                     processBlock
+                        nullTracer
                         True
                         transact
                         Rollbacks
@@ -452,6 +457,7 @@ spec = describe "E2E Runner" $ do
                     val3 = mkTestValue "output3"
                 phase2 <-
                     processBlock
+                        nullTracer
                         True
                         transact
                         Rollbacks
@@ -464,6 +470,7 @@ spec = describe "E2E Runner" $ do
                 -- Slot 3: empty block
                 _ <-
                     processBlock
+                        nullTracer
                         True
                         transact
                         Rollbacks
@@ -477,6 +484,7 @@ spec = describe "E2E Runner" $ do
         withFreshDB $ \phase transact -> do
             phase1 <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -508,6 +516,7 @@ spec = describe "E2E Runner" $ do
             -- Follow one block
             _ <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -530,6 +539,7 @@ spec = describe "E2E Runner" $ do
             -- Auto-pruning kicks in when count > k+1
             phase1 <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -539,6 +549,7 @@ spec = describe "E2E Runner" $ do
                     phase
             phase2 <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -548,6 +559,7 @@ spec = describe "E2E Runner" $ do
                     phase1
             _ <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -601,6 +613,7 @@ spec = describe "E2E Runner" $ do
             -- Bootstrap: insert what block 282639 needs
             phase1 <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -613,6 +626,7 @@ spec = describe "E2E Runner" $ do
             -- Block 282639: 1 delete + 2 inserts
             phase2 <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -629,6 +643,7 @@ spec = describe "E2E Runner" $ do
             -- Block 283086: delete d4be#1
             _ <-
                 processBlock
+                    nullTracer
                     True
                     transact
                     Rollbacks
@@ -659,6 +674,7 @@ spec = describe "E2E Runner" $ do
                     val1 = mkTestValue "output1"
                 phase1 <-
                     processBlock
+                        nullTracer
                         False
                         transact
                         Rollbacks
@@ -678,6 +694,7 @@ spec = describe "E2E Runner" $ do
             withFreshDBRestoration $ \phase transact -> do
                 _ <-
                     processBlock
+                        nullTracer
                         False
                         transact
                         Rollbacks
@@ -698,6 +715,7 @@ spec = describe "E2E Runner" $ do
                 -- Restore a block
                 phase1 <-
                     processBlock
+                        nullTracer
                         False
                         transact
                         Rollbacks
@@ -717,6 +735,7 @@ spec = describe "E2E Runner" $ do
                         -- Process another block in Following
                         phase3 <-
                             processBlock
+                                nullTracer
                                 True
                                 transact
                                 Rollbacks
@@ -740,6 +759,7 @@ spec = describe "E2E Runner" $ do
                 -- Restore 3 blocks
                 phase1 <-
                     processBlock
+                        nullTracer
                         False
                         transact
                         Rollbacks
@@ -751,6 +771,7 @@ spec = describe "E2E Runner" $ do
                         phase
                 phase2 <-
                     processBlock
+                        nullTracer
                         False
                         transact
                         Rollbacks
@@ -762,6 +783,7 @@ spec = describe "E2E Runner" $ do
                         phase1
                 phase3 <-
                     processBlock
+                        nullTracer
                         False
                         transact
                         Rollbacks
@@ -787,6 +809,7 @@ spec = describe "E2E Runner" $ do
                         -- Follow 2 more blocks
                         phase5 <-
                             processBlock
+                                nullTracer
                                 True
                                 transact
                                 Rollbacks
@@ -798,6 +821,7 @@ spec = describe "E2E Runner" $ do
                                 phase4
                         phase6 <-
                             processBlock
+                                nullTracer
                                 True
                                 transact
                                 Rollbacks
@@ -839,6 +863,7 @@ spec = describe "E2E Runner" $ do
                         foldM_
                             ( \p slot ->
                                 processBlock
+                                    nullTracer
                                     True
                                     transact
                                     Rollbacks
@@ -867,6 +892,7 @@ spec = describe "E2E Runner" $ do
                             foldM
                                 ( \p slot ->
                                     processBlock
+                                        nullTracer
                                         True
                                         transact
                                         Rollbacks
@@ -912,6 +938,7 @@ spec = describe "E2E Runner" $ do
                 -- Slot 1: empty block
                 phase1 <-
                     processBlock
+                        nullTracer
                         True
                         transact
                         Rollbacks
@@ -922,6 +949,7 @@ spec = describe "E2E Runner" $ do
                 -- Slot 2: insert key
                 phase2 <-
                     processBlock
+                        nullTracer
                         True
                         transact
                         Rollbacks
@@ -967,6 +995,7 @@ spec = describe "E2E Runner" $ do
                 withDBAt dir $ \phase transact -> do
                     phase1 <-
                         processBlock
+                            nullTracer
                             True
                             transact
                             Rollbacks
@@ -978,6 +1007,7 @@ spec = describe "E2E Runner" $ do
                             phase
                     _ <-
                         processBlock
+                            nullTracer
                             True
                             transact
                             Rollbacks
@@ -1039,6 +1069,7 @@ spec = describe "E2E Runner" $ do
                     foldM
                         ( \p (slot, ops) ->
                             processBlock
+                                nullTracer
                                 True
                                 runTx
                                 Rollbacks
@@ -1067,6 +1098,7 @@ spec = describe "E2E Runner" $ do
                             go p ((slot, ops) : rest) = do
                                 p' <-
                                     processBlock
+                                        nullTracer
                                         True
                                         transact
                                         Rollbacks
@@ -1084,6 +1116,7 @@ spec = describe "E2E Runner" $ do
                                 go p ((slot, ops) : rest) = do
                                     p' <-
                                         processBlock
+                                            nullTracer
                                             True
                                             transact
                                             Rollbacks
@@ -1124,6 +1157,7 @@ spec = describe "E2E Runner" $ do
                                 go p ((slot, ops) : rest) = do
                                     p' <-
                                         processBlock
+                                            nullTracer
                                             True
                                             transact
                                             Rollbacks
@@ -1139,6 +1173,7 @@ spec = describe "E2E Runner" $ do
                                 go p ((slot, ops) : rest) = do
                                     p' <-
                                         processBlock
+                                            nullTracer
                                             True
                                             transact
                                             Rollbacks

--- a/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
+++ b/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
@@ -58,6 +58,7 @@ import Codec.CBOR.Read qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
 import Control.Lens (lazy, prism', strict, view)
 import Control.Monad.IO.Class (liftIO)
+import Control.Tracer (nullTracer)
 import Data.Aeson (eitherDecode)
 import Data.ByteArray.Encoding
     ( Base (..)
@@ -564,6 +565,7 @@ spec = do
                         val1 = mkTestValue "output1"
                     phase1 <-
                         processBlock
+                            nullTracer
                             True
                             transact
                             Rollbacks
@@ -577,6 +579,7 @@ spec = do
                         val2 = mkTestValue "output2"
                     _ <-
                         processBlock
+                            nullTracer
                             True
                             transact
                             Rollbacks
@@ -634,6 +637,7 @@ spec = do
                         testTxIx = 0 :: Word16
                     _ <-
                         processBlock
+                            nullTracer
                             True
                             transact
                             Rollbacks
@@ -708,6 +712,7 @@ spec = do
                         value3 = BL.fromStrict $ "BBBB" <> "output3-data"
                     _ <-
                         processBlock
+                            nullTracer
                             True
                             transact
                             Rollbacks

--- a/lib/Cardano/UTxOCSMT/Application/Database/Backend.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Database/Backend.hs
@@ -5,6 +5,7 @@ module Cardano.UTxOCSMT.Application.Database.Backend
       -- * Re-exports for Application.hs
     , Backend.Init (..)
     , Runner.Phase (..)
+    , Runner.RunnerEvent (..)
     , Runner.processBlock
     , Runner.rollbackTo
     , Runner.rollbackCount


### PR DESCRIPTION
## Summary

- **SyncPhase** now has three values: `Restoring`, `Following`, `Synced`
- Computed on every block from Runner phase + slot distance to tip
- API returns 503 unless `Synced` (within `--sync-threshold` slots of tip)
- Wire chain-follower `RunnerEvent` tracer into `ApplicationTrace`
- Add `SyncThreshold` newtype, used in Options and Query
- Rename `atTip` to `withinStabilityWindow` throughout
- Bump chain-follower, cardano-node-clients, rocksdb-haskell, rocksdb-kv-transactions

Closes #207
Closes #210

## Test plan

- [x] `just CI` passes locally (61 tests)
- [ ] CI green on GitHub
- [ ] Deploy and verify phase transitions visible in logs
- [ ] Verify API returns 200 when synced, 503 when behind