### PR TITLE
fix: adapt to haskell-mts proofRootHash removal

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Query.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Query.hs
@@ -24,7 +24,7 @@ import CSMT.Hashes
     , generateInclusionProof
     , renderHash
     )
-import CSMT.Interface (FromKV (..))
+import CSMT.Interface (FromKV (..), root)
 import CSMT.Proof.Exclusion
     ( buildExclusionProof
     , verifyExclusionProof
@@ -196,10 +196,12 @@ queryExclusionProof (RunTransaction runTx) txIdText txIx =
         let treeKey = case mVal of
                 Just v -> pfx v <> baseKey
                 Nothing -> baseKey
-        mProof <- buildExclusionProof [] CSMTCol hashing treeKey
-        pure $ case mProof of
-            Nothing -> False
-            Just proof -> verifyExclusionProof hashing proof
+        mProof <- buildExclusionProof [] CSMTCol treeKey
+        mr <- root hashing CSMTCol []
+        pure $ case (mProof, mr) of
+            (Just proof, Just r) ->
+                verifyExclusionProof hashing r proof
+            _ -> False
   where
     txIn = unsafeMkTxIn (toShort $ unsafeDecodeBase16Text txIdText) txIx
 

--- a/cabal.project
+++ b/cabal.project
@@ -26,8 +26,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: a37b352041a1f90c00940ede0336dcc8d85140ee
-  --sha256: 0lfg6clc7nx8wnlsqz9haqmgw9a8kcm0cg098q44azs03hq3aqym
+  tag: e54d9f3c790d07a9ae706397945da60c1a10c11e
+  --sha256: 03m6br7pqbn87z70baffbcrz4qvsc2qbwknv48nvvvpgyzkdg84i
 
 source-repository-package
   type: git


### PR DESCRIPTION
Closes #226

Bump haskell-mts to e54d9f3 which removes `proofRootHash` from `InclusionProof`.

- `buildExclusionProof` no longer takes `Hashing` parameter
- `verifyExclusionProof` now takes trusted root — query it from tree before verifying

Upstream: lambdasistemi/haskell-mts#138