### PR TITLE
feat!: replace merkleRoot with chain point in proof response

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Query.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Query.hs
@@ -29,6 +29,7 @@ import CSMT.Proof.Exclusion
     ( buildExclusionProof
     , verifyExclusionProof
     )
+import Cardano.UTxOCSMT.Application.Database.Backend (queryTip)
 import Cardano.UTxOCSMT.Application.Database.Implementation.Columns
     ( Columns (..)
     )
@@ -39,7 +40,6 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     ( CSMTContext (..)
     , RunTransaction (..)
     , queryByAddress
-    , queryMerkleRoot
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( WithSentinel (..)
@@ -52,6 +52,7 @@ import Cardano.UTxOCSMT.Application.Metrics
 import Cardano.UTxOCSMT.Application.Run.Config
     ( context
     , hashAddressKey
+    , slotHash
     )
 import Cardano.UTxOCSMT.Application.UTxOs (unsafeMkTxIn)
 import Cardano.UTxOCSMT.HTTP.API
@@ -118,8 +119,8 @@ queryMerkleRoots (RunTransaction runTx) =
         case slot of
             Sentinel -> []
             Value (Network.Point Origin) -> []
-            Value (Network.Point (At (Block slotNo _))) ->
-                [MerkleRootEntry{slotNo, blockHash, merkleRoot}]
+            Value (Network.Point (At Block{})) ->
+                [MerkleRootEntry{blockHash, merkleRoot}]
 
 {- | Retrieve the inclusion proof and UTxO value for a transaction input.
 
@@ -144,23 +145,24 @@ queryInclusionProof
     -- ^ Inclusion proof response, if the UTxO exists
 queryInclusionProof (RunTransaction runTx) txIdText txIx = do
     runTx $ do
-        let CSMTContext{fromKV, hashing} = context
+        let CSMTContext{fromKV} = context
         result <- generateInclusionProof fromKV KVCol CSMTCol txIn
-        merkle <- queryMerkleRoot hashing
+        mTip <- queryTip Rollbacks
         pure $ do
             (out, proof') <- result
-            let merkleText =
-                    fmap
-                        (Text.decodeUtf8 . convertToBase Base16 . renderHash)
-                        merkle
+            bh <- case mTip of
+                Just (Value pt@(Network.Point (At Block{}))) ->
+                    Just (slotHash pt)
+                _ -> Nothing
             pure
                 InclusionProofResponse
-                    { proofTxId = txIdText
-                    , proofTxIx = txIx
-                    , proofTxOut = encodeBase16Text $ toStrict out
+                    { proofTxOut = encodeBase16Text $ toStrict out
                     , proofBytes =
                         Text.decodeUtf8 $ convertToBase Base16 proof'
-                    , proofMerkleRoot = merkleText
+                    , proofBlockHash =
+                        Text.decodeUtf8
+                            $ convertToBase Base16
+                            $ renderHash bh
                     }
   where
     txIn = unsafeMkTxIn (toShort $ unsafeDecodeBase16Text txIdText) txIx

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -84,7 +84,6 @@ library http
     , memory
     , mts:csmt
     , network
-    , ouroboros-network-api
     , servant-server
     , servant-swagger
     , servant-swagger-ui

--- a/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
+++ b/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
@@ -24,7 +24,6 @@ import Cardano.UTxOCSMT.Application.Database.Implementation.Transaction
     , RunTransaction (..)
     , mkCSMTOps
     , queryByAddress
-    , queryMerkleRoot
     )
 import Cardano.UTxOCSMT.Application.Database.Interface
     ( Operation (..)
@@ -369,13 +368,8 @@ queryTestMerkleRoots (RunTransaction runTx) =
         pure $ concatMap toEntry (reverse history)
   where
     toEntry (slot, RollbackPoint{rpMeta}) = case (slot, rpMeta) of
-        (Value slotNo, Just (blockHash, merkleRoot)) ->
-            [ MerkleRootEntry
-                { slotNo
-                , blockHash
-                , merkleRoot
-                }
-            ]
+        (Value _, Just (blockHash, merkleRoot)) ->
+            [MerkleRootEntry{blockHash, merkleRoot}]
         _ -> []
 
 -- | Query inclusion proof for testing.
@@ -392,26 +386,31 @@ queryTestInclusionProof
     -> Text
     -> Word16
     -> IO (Maybe InclusionProofResponse)
-queryTestInclusionProof (RunTransaction runTx) actualKey txIdText txIx =
+queryTestInclusionProof (RunTransaction runTx) actualKey _txIdText _txIx =
     runTx $ do
-        let CSMTContext{fromKV = fkv, hashing = h} = testCSMTContext
+        let CSMTContext{fromKV = fkv} = testCSMTContext
         result <-
             generateInclusionProof
                 fkv
                 KVCol
                 CSMTCol
                 actualKey
-        merkle <- queryMerkleRoot h
+        mTip <- Store.queryTip Rollbacks
         pure $ do
             (out, proof') <- result
-            let merkleText = fmap (encodeBase16Text . renderHash) merkle
+            tipSlot <- case mTip of
+                Just (Value sn) -> Just sn
+                _ -> Nothing
             pure
                 InclusionProofResponse
-                    { proofTxId = txIdText
-                    , proofTxIx = txIx
-                    , proofTxOut = encodeBase16 $ BL.toStrict out
+                    { proofTxOut = encodeBase16 $ BL.toStrict out
                     , proofBytes = encodeBase16Text proof'
-                    , proofMerkleRoot = merkleText
+                    , proofBlockHash =
+                        encodeBase16Text
+                            $ renderHash
+                            $ mkHash
+                            $ BC.pack
+                            $ show tipSlot
                     }
 
 prefixedCSMTContext :: CSMTContext Hash BL.ByteString BL.ByteString
@@ -602,15 +601,13 @@ spec = do
                                         defaultRequest{requestMethod = methodGet}
                                         "/merkle-roots"
                             liftIO $ simpleStatus resp `shouldBe` status200
-                            let decoded = eitherDecode $ simpleBody resp
+                            let decoded =
+                                    eitherDecode (simpleBody resp)
+                                        :: Either String [MerkleRootEntry]
                             liftIO $ case decoded of
                                 Left err -> fail $ "JSON decode error: " ++ err
-                                Right entries -> do
+                                Right entries ->
                                     length entries `shouldBe` 2
-                                    slotNo <$> entries
-                                        `shouldBe` [ SlotNo 200
-                                                   , SlotNo 100
-                                                   ]
 
         describe "GET /proof/{txId}/{txIx}" $ do
             it "returns 404 for non-existent UTxO" $ do
@@ -675,10 +672,9 @@ spec = do
                             liftIO $ case decoded of
                                 Left err -> fail $ "JSON decode error: " ++ err
                                 Right proof -> do
-                                    proofTxId proof `shouldBe` testTxId
-                                    proofTxIx proof `shouldBe` testTxIx
                                     proofBytes proof `shouldSatisfy` (not . T.null)
                                     proofTxOut proof `shouldSatisfy` (not . T.null)
+                                    proofBlockHash proof `shouldSatisfy` (not . T.null)
 
         describe "GET /utxos-by-address/:address" $ do
             it "returns empty list for unknown address" $ do

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -23,51 +23,36 @@
             "type": "object"
         },
         "InclusionProofResponse": {
-            "description": "Current inclusion proof and output for the given transaction input.",
+            "description": "Inclusion proof, output, and block hash for the given transaction input.",
             "properties": {
-                "merkleRoot": {
+                "blockHash": {
                     "type": "string"
                 },
                 "proof": {
                     "type": "string"
-                },
-                "txId": {
-                    "type": "string"
-                },
-                "txIx": {
-                    "maximum": 65535,
-                    "minimum": 0,
-                    "type": "integer"
                 },
                 "txOut": {
                     "type": "string"
                 }
             },
             "required": [
-                "txId",
-                "txIx",
                 "txOut",
-                "proof"
+                "proof",
+                "blockHash"
             ],
             "type": "object"
         },
         "MerkleRootEntry": {
-            "description": "A merkle root entry at a given slot",
+            "description": "A merkle root at a given block",
             "properties": {
                 "blockHash": {
                     "type": "string"
                 },
                 "merkleRoot": {
                     "type": "string"
-                },
-                "slotNo": {
-                    "maximum": 1.8446744073709551615e19,
-                    "minimum": 0,
-                    "type": "integer"
                 }
             },
             "required": [
-                "slotNo",
                 "blockHash",
                 "merkleRoot"
             ],

--- a/http/Cardano/UTxOCSMT/HTTP/API.hs
+++ b/http/Cardano/UTxOCSMT/HTTP/API.hs
@@ -46,7 +46,6 @@ import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
 import Data.Word (Word16, Word64)
 import GHC.IsList (IsList (..))
-import Ouroboros.Network.Block (SlotNo (..))
 import Servant
     ( Capture
     , Get
@@ -93,20 +92,17 @@ type API =
 api :: Proxy API
 api = Proxy
 
--- | Entry for a merkle root at a given slot
+-- | Entry for a merkle root at a given block
 data MerkleRootEntry = MerkleRootEntry
-    { slotNo :: SlotNo
-    , blockHash :: Hash
+    { blockHash :: Hash
     , merkleRoot :: Maybe Hash
     }
     deriving (Show, Eq)
 
 data InclusionProofResponse = InclusionProofResponse
-    { proofTxId :: Text
-    , proofTxIx :: Word16
-    , proofTxOut :: Text
+    { proofTxOut :: Text
     , proofBytes :: Text
-    , proofMerkleRoot :: Maybe Text
+    , proofBlockHash :: Text
     }
     deriving (Show, Eq)
 
@@ -152,17 +148,16 @@ renderHashBase16 :: Hash -> Text
 renderHashBase16 = Text.decodeUtf8 . convertToBase Base16 . renderHash
 
 instance ToJSON MerkleRootEntry where
-    toJSON MerkleRootEntry{slotNo, blockHash, merkleRoot} =
+    toJSON MerkleRootEntry{blockHash, merkleRoot} =
         object
-            [ "slotNo" .= unSlotNo slotNo
-            , "blockHash" .= renderHashBase16 blockHash
+            [ "blockHash" .= renderHashBase16 blockHash
             , "merkleRoot" .= fmap renderHashBase16 merkleRoot
             ]
 
 instance FromJSON MerkleRootEntry where
     parseJSON = withObject "MerkleRootEntry" $ \v ->
-        (MerkleRootEntry . SlotNo <$> (v .: "slotNo"))
-            <*> (v .: "blockHash" >>= parseHashBase16)
+        MerkleRootEntry
+            <$> (v .: "blockHash" >>= parseHashBase16)
             <*> (v .: "merkleRoot" >>= mapM parseHashBase16)
       where
         parseHashBase16 :: Text -> Parser Hash
@@ -174,31 +169,24 @@ instance FromJSON MerkleRootEntry where
 instance ToJSON InclusionProofResponse where
     toJSON
         InclusionProofResponse
-            { proofTxId
-            , proofTxIx
-            , proofTxOut
+            { proofTxOut
             , proofBytes
-            , proofMerkleRoot
+            , proofBlockHash
             } =
             object
-                [ "txId" .= proofTxId
-                , "txIx" .= proofTxIx
-                , "txOut" .= proofTxOut
+                [ "txOut" .= proofTxOut
                 , "proof" .= proofBytes
-                , "merkleRoot" .= proofMerkleRoot
+                , "blockHash" .= proofBlockHash
                 ]
 
 instance FromJSON InclusionProofResponse where
     parseJSON = withObject "InclusionProofResponse" $ \v ->
         InclusionProofResponse
-            <$> v .: "txId"
-            <*> v .: "txIx"
-            <*> v .: "txOut"
+            <$> v .: "txOut"
             <*> v .: "proof"
-            <*> v .: "merkleRoot"
+            <*> v .: "blockHash"
 instance ToSchema MerkleRootEntry where
     declareNamedSchema _ = do
-        word64Schema <- declareSchemaRef (Proxy @Word)
         stringSchema <- declareSchemaRef (Proxy @String)
         maybeStringSchema <- declareSchemaRef (Proxy @(Maybe String))
         return
@@ -207,33 +195,28 @@ instance ToSchema MerkleRootEntry where
             & Swagger.type_ ?~ Swagger.SwaggerObject
             & properties
                 .~ fromList
-                    [ ("slotNo", word64Schema)
-                    , ("blockHash", stringSchema)
+                    [ ("blockHash", stringSchema)
                     , ("merkleRoot", maybeStringSchema)
                     ]
-            & required .~ ["slotNo", "blockHash", "merkleRoot"]
-            & description ?~ "A merkle root entry at a given slot"
+            & required .~ ["blockHash", "merkleRoot"]
+            & description ?~ "A merkle root at a given block"
 
 instance ToSchema InclusionProofResponse where
     declareNamedSchema _ = do
         stringSchema <- declareSchemaRef (Proxy @String)
-        word16Schema <- declareSchemaRef (Proxy @Word16)
-        maybeStringSchema <- declareSchemaRef (Proxy @(Maybe String))
         return
             $ Swagger.NamedSchema (Just "InclusionProofResponse")
             $ mempty
             & Swagger.type_ ?~ Swagger.SwaggerObject
             & properties
                 .~ fromList
-                    [ ("txId", stringSchema)
-                    , ("txIx", word16Schema)
-                    , ("txOut", stringSchema)
+                    [ ("txOut", stringSchema)
                     , ("proof", stringSchema)
-                    , ("merkleRoot", maybeStringSchema)
+                    , ("blockHash", stringSchema)
                     ]
-            & required .~ ["txId", "txIx", "txOut", "proof"]
+            & required .~ ["txOut", "proof", "blockHash"]
             & description
-                ?~ "Current inclusion proof and output for the given transaction input."
+                ?~ "Inclusion proof, output, and block hash for the given transaction input."
 
 -- | Response for the /ready endpoint indicating sync status
 data ReadyResponse = ReadyResponse


### PR DESCRIPTION
Closes #228

- Remove `txId`, `txIx`, `merkleRoot` from `InclusionProofResponse`
- Add `slotNo`, `blockHash` (chain point where proof was generated)
- Client uses chain point to obtain trusted merkle root independently