### PR TITLE
feat: sign merkle roots with Ed25519 institution key

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Main.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Main.hs
@@ -69,7 +69,12 @@ import Cardano.UTxOCSMT.Application.Run.Traces
     , renderThrottledMainTraces
     , stealMetricsEvent
     )
+import Cardano.UTxOCSMT.HTTP.API (SigningKeyResponse (..))
 import Cardano.UTxOCSMT.HTTP.Server (runAPIServer, runDocsServer)
+import Cardano.UTxOCSMT.Signing
+    ( parseSigningKey
+    , renderPublicKey
+    )
 import ChainFollower.Backend qualified as Backend
 import ChainFollower.Runner (Phase (..), readCheckpoint)
 import Control.Concurrent.Async (async, link)
@@ -83,8 +88,10 @@ import Control.Tracer
     , nullTracer
     , traceWith
     )
+import Data.ByteArray.Encoding (Base (..), convertToBase)
 import Data.ByteString.Lazy qualified as BL
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Text.Encoding qualified as Text
 import Data.Time.Clock (diffUTCTime)
 import Data.Tracer.Fold (foldTracer)
 import Data.Tracer.Intercept (intercept)
@@ -133,11 +140,25 @@ main = withUtf8 $ do
         , logPath
         , apiPort
         , headersQueueSize
+        , signingKey = mSigningKeyBytes
         } <-
         runParser
             version
             "Tracking cardano UTxOs in a CSMT in a rocksDB database"
             optionsParser
+    let mSigningConfig = mSigningKeyBytes >>= parseSigningKey
+        signingKeyResponse =
+            fmap
+                ( \sc ->
+                    SigningKeyResponse
+                        { publicKey =
+                            Text.decodeUtf8
+                                $ convertToBase Base16
+                                $ renderPublicKey sc
+                        }
+                )
+                mSigningConfig
+
     logTracer logPath $ \basicTracer -> do
         let appTracer = basicTracer
 
@@ -233,11 +254,12 @@ main = withUtf8 $ do
                     runAPIServer
                         port
                         (readIORef metricsRef)
-                        (queryMerkleRoots runner)
+                        (queryMerkleRoots mSigningConfig runner)
                         (queryInclusionProof runner)
                         (queryUTxOsByAddress runner)
                         getReadyResponse
                         (queryAwait commitNotify runner)
+                        (pure signingKeyResponse)
 
             SetupResult
                 { setupStartingPoint

--- a/application/Cardano/UTxOCSMT/Application/Run/Query.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Query.hs
@@ -68,6 +68,10 @@ import Cardano.UTxOCSMT.HTTP.Base16
     , unsafeDecodeBase16Text
     )
 import Cardano.UTxOCSMT.Ouroboros.Types (Header, Point)
+import Cardano.UTxOCSMT.Signing
+    ( SigningConfig
+    , signMerkleRoot
+    )
 import Control.Concurrent.STM
     ( TVar
     , atomically
@@ -101,7 +105,9 @@ block hash, and merkle root for each processed block. Results are
 filtered to exclude Origin points.
 -}
 queryMerkleRoots
-    :: RunTransaction
+    :: Maybe SigningConfig
+    -- ^ Signing configuration (Nothing = unsigned)
+    -> RunTransaction
         ColumnFamily
         BatchOp
         Point
@@ -112,15 +118,26 @@ queryMerkleRoots
     -- ^ Database transaction runner
     -> IO [MerkleRootEntry]
     -- ^ List of merkle root entries
-queryMerkleRoots (RunTransaction runTx) =
+queryMerkleRoots mSigning (RunTransaction runTx) =
     runTx $ concatMap toMerkleRootEntry <$> getAllMerkleRoots
   where
-    toMerkleRootEntry (slot, blockHash, merkleRoot) =
+    toMerkleRootEntry (slot, bh, mr) =
         case slot of
             Sentinel -> []
             Value (Network.Point Origin) -> []
             Value (Network.Point (At Block{})) ->
-                [MerkleRootEntry{blockHash, merkleRoot}]
+                [ MerkleRootEntry
+                    { blockHash = bh
+                    , merkleRoot = mr
+                    , signature = do
+                        sc <- mSigning
+                        root <- mr
+                        pure
+                            $ Text.decodeUtf8
+                            $ convertToBase Base16
+                            $ signMerkleRoot sc bh root
+                    }
+                ]
 
 {- | Retrieve the inclusion proof and UTxO value for a transaction input.
 

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -188,6 +188,7 @@ library library
     Cardano.UTxOCSMT.Ouroboros.Connection
     Cardano.UTxOCSMT.Ouroboros.ConnectionN2C
     Cardano.UTxOCSMT.Ouroboros.Types
+    Cardano.UTxOCSMT.Signing
 
   build-depends:
     , aeson
@@ -195,6 +196,7 @@ library library
     , base                                     <5
     , bytestring
     , cardano-crypto-class
+    , crypton
     , cardano-crypto-wrapper
     , cardano-data
     , cardano-ledger-alonzo

--- a/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
+++ b/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
@@ -369,7 +369,12 @@ queryTestMerkleRoots (RunTransaction runTx) =
   where
     toEntry (slot, RollbackPoint{rpMeta}) = case (slot, rpMeta) of
         (Value _, Just (blockHash, merkleRoot)) ->
-            [MerkleRootEntry{blockHash, merkleRoot}]
+            [ MerkleRootEntry
+                { blockHash
+                , merkleRoot
+                , signature = Nothing
+                }
+            ]
         _ -> []
 
 -- | Query inclusion proof for testing.
@@ -485,7 +490,9 @@ session
     -> IO ReadyResponse
     -> Session b
     -> IO b
-session a b c d e = flip runSession $ apiApp a b c d e (\_ _ _ -> pure Nothing)
+session a b c d e =
+    flip runSession
+        $ apiApp a b c d e (\_ _ _ -> pure Nothing) (pure Nothing)
 
 spec :: Spec
 spec = do

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -43,12 +43,15 @@
             "type": "object"
         },
         "MerkleRootEntry": {
-            "description": "A merkle root at a given block",
+            "description": "A merkle root at a given block, optionally signed",
             "properties": {
                 "blockHash": {
                     "type": "string"
                 },
                 "merkleRoot": {
+                    "type": "string"
+                },
+                "signature": {
                     "type": "string"
                 }
             },
@@ -234,6 +237,18 @@
             ],
             "type": "object"
         },
+        "SigningKeyResponse": {
+            "description": "Ed25519 public key for verifying merkle root signatures",
+            "properties": {
+                "publicKey": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicKey"
+            ],
+            "type": "object"
+        },
         "SyncPhase": {
             "description": "Current synchronization phase: restoring, replaying, following, or synced",
             "enum": [
@@ -404,6 +419,21 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/ReadyResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/signing-key": {
+            "get": {
+                "produces": [
+                    "application/json;charset=utf-8"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/SigningKeyResponse"
                         }
                     }
                 }

--- a/http/Cardano/UTxOCSMT/HTTP/API.hs
+++ b/http/Cardano/UTxOCSMT/HTTP/API.hs
@@ -19,6 +19,7 @@ module Cardano.UTxOCSMT.HTTP.API
     , DOCS
     , docs
     , MerkleRootEntry (..)
+    , SigningKeyResponse (..)
     , InclusionProofResponse (..)
     , UTxOByAddressEntry (..)
     , ReadyResponse (..)
@@ -87,6 +88,8 @@ type API =
             :> Capture "txIx" Word16
             :> QueryParam "timeout" Int
             :> Get '[JSON] AwaitResponse
+        :<|> "signing-key"
+            :> Get '[JSON] SigningKeyResponse
 
 -- | Proxy for the API
 api :: Proxy API
@@ -96,6 +99,15 @@ api = Proxy
 data MerkleRootEntry = MerkleRootEntry
     { blockHash :: Hash
     , merkleRoot :: Maybe Hash
+    , signature :: Maybe Text
+    -- ^ Ed25519 signature over @blockHash <> merkleRoot@ (base16)
+    }
+    deriving (Show, Eq)
+
+-- | Public key for verifying merkle root signatures
+newtype SigningKeyResponse = SigningKeyResponse
+    { publicKey :: Text
+    -- ^ Ed25519 public key (base16)
     }
     deriving (Show, Eq)
 
@@ -148,23 +160,33 @@ renderHashBase16 :: Hash -> Text
 renderHashBase16 = Text.decodeUtf8 . convertToBase Base16 . renderHash
 
 instance ToJSON MerkleRootEntry where
-    toJSON MerkleRootEntry{blockHash, merkleRoot} =
+    toJSON MerkleRootEntry{blockHash, merkleRoot, signature} =
         object
-            [ "blockHash" .= renderHashBase16 blockHash
-            , "merkleRoot" .= fmap renderHashBase16 merkleRoot
-            ]
+            $ [ "blockHash" .= renderHashBase16 blockHash
+              , "merkleRoot" .= fmap renderHashBase16 merkleRoot
+              ]
+                <> maybe [] (\s -> ["signature" .= s]) signature
 
 instance FromJSON MerkleRootEntry where
     parseJSON = withObject "MerkleRootEntry" $ \v ->
         MerkleRootEntry
             <$> (v .: "blockHash" >>= parseHashBase16)
             <*> (v .: "merkleRoot" >>= mapM parseHashBase16)
+            <*> v .:? "signature"
       where
         parseHashBase16 :: Text -> Parser Hash
         parseHashBase16 txt =
             case decodeBase16Text txt of
                 Left err -> fail $ "Invalid base16 hash: " ++ err
                 Right h -> return h
+
+instance ToJSON SigningKeyResponse where
+    toJSON SigningKeyResponse{publicKey} =
+        object ["publicKey" .= publicKey]
+
+instance FromJSON SigningKeyResponse where
+    parseJSON = withObject "SigningKeyResponse" $ \v ->
+        SigningKeyResponse <$> v .: "publicKey"
 
 instance ToJSON InclusionProofResponse where
     toJSON
@@ -197,9 +219,24 @@ instance ToSchema MerkleRootEntry where
                 .~ fromList
                     [ ("blockHash", stringSchema)
                     , ("merkleRoot", maybeStringSchema)
+                    , ("signature", maybeStringSchema)
                     ]
             & required .~ ["blockHash", "merkleRoot"]
-            & description ?~ "A merkle root at a given block"
+            & description
+                ?~ "A merkle root at a given block, optionally signed"
+
+instance ToSchema SigningKeyResponse where
+    declareNamedSchema _ = do
+        stringSchema <- declareSchemaRef (Proxy @String)
+        return
+            $ Swagger.NamedSchema (Just "SigningKeyResponse")
+            $ mempty
+            & Swagger.type_ ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList [("publicKey", stringSchema)]
+            & required .~ ["publicKey"]
+            & description
+                ?~ "Ed25519 public key for verifying merkle root signatures"
 
 instance ToSchema InclusionProofResponse where
     declareNamedSchema _ = do

--- a/http/Cardano/UTxOCSMT/HTTP/Server.hs
+++ b/http/Cardano/UTxOCSMT/HTTP/Server.hs
@@ -16,6 +16,7 @@ import Cardano.UTxOCSMT.HTTP.API
     , InclusionProofResponse
     , MerkleRootEntry
     , ReadyResponse (..)
+    , SigningKeyResponse
     , UTxOByAddressEntry
     , api
     , docs
@@ -53,8 +54,9 @@ apiServer
     -> (Text -> IO (Either String [UTxOByAddressEntry]))
     -> IO ReadyResponse
     -> (Text -> Word16 -> Maybe Int -> IO (Maybe AwaitResponse))
+    -> IO (Maybe SigningKeyResponse)
     -> Server API
-apiServer getMetrics getMerkleRoots getProof getByAddress getReady getAwait =
+apiServer getMetrics getMerkleRoots getProof getByAddress getReady getAwait getSigningKey =
     prometheusHandler
         :<|> metricsHandler
         :<|> merkleRootsHandler
@@ -62,6 +64,7 @@ apiServer getMetrics getMerkleRoots getProof getByAddress getReady getAwait =
         :<|> byAddressHandler
         :<|> readyHandler
         :<|> awaitHandler
+        :<|> signingKeyHandler
   where
     metricsHandler = do
         r <- liftIO getMetrics
@@ -104,6 +107,10 @@ apiServer getMetrics getMerkleRoots getProof getByAddress getReady getAwait =
             pure
             r
 
+    signingKeyHandler = do
+        r <- liftIO getSigningKey
+        maybe (throwError err404) pure r
+
 -- | HTTP 408 Request Timeout
 err408 :: ServerError
 err408 =
@@ -122,8 +129,9 @@ apiApp
     -> (Text -> IO (Either String [UTxOByAddressEntry]))
     -> IO ReadyResponse
     -> (Text -> Word16 -> Maybe Int -> IO (Maybe AwaitResponse))
+    -> IO (Maybe SigningKeyResponse)
     -> Application
-apiApp getMetrics getMerkleRoots getProof getByAddress getReady getAwait =
+apiApp getMetrics getMerkleRoots getProof getByAddress getReady getAwait getSigningKey =
     simpleCors
         $ serve api
         $ apiServer
@@ -133,6 +141,7 @@ apiApp getMetrics getMerkleRoots getProof getByAddress getReady getAwait =
             getByAddress
             getReady
             getAwait
+            getSigningKey
 
 {- | Run the API server on the specified port
 Takes a port number, an IO action that provides the current Metrics,
@@ -148,8 +157,9 @@ runAPIServer
     -> (Text -> IO (Either String [UTxOByAddressEntry]))
     -> IO ReadyResponse
     -> (Text -> Word16 -> Maybe Int -> IO (Maybe AwaitResponse))
+    -> IO (Maybe SigningKeyResponse)
     -> IO ()
-runAPIServer port getMetrics getMerkleRoots getProof getByAddress getReady getAwait =
+runAPIServer port getMetrics getMerkleRoots getProof getByAddress getReady getAwait getSigningKey =
     run (fromIntegral port)
         $ apiApp
             getMetrics
@@ -158,6 +168,7 @@ runAPIServer port getMetrics getMerkleRoots getProof getByAddress getReady getAw
             getByAddress
             getReady
             getAwait
+            getSigningKey
 
 -- | WAI Application for the documentation
 docsApp :: Maybe PortNumber -> Application

--- a/lib/Cardano/UTxOCSMT/Application/Options.hs
+++ b/lib/Cardano/UTxOCSMT/Application/Options.hs
@@ -23,6 +23,9 @@ import Cardano.UTxOCSMT.Application.BlockFetch
 import Cardano.UTxOCSMT.Application.Metrics.Types
     ( SyncThreshold (..)
     )
+import Data.ByteArray.Encoding (Base (..), convertFromBase)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
 import Data.Word (Word16)
 import Network.Socket (PortNumber)
 import OptEnvConf
@@ -90,6 +93,8 @@ data Options = Options
     -- ^ Path to shelley-genesis.json (required for security parameter)
     , byronGenesisFile :: Maybe FilePath
     -- ^ Path to byron-genesis.json for bootstrap from genesis
+    , signingKey :: Maybe ByteString
+    -- ^ Ed25519 secret key for signing merkle roots (base16)
     }
 
 -- | Option to specify a YAML configuration file
@@ -281,6 +286,26 @@ byronGenesisFileOption =
             , option
             ]
 
+signingKeyOption :: Parser (Maybe ByteString)
+signingKeyOption =
+    fmap (>>= decodeHex) . optional
+        $ setting
+            [ long "signing-key"
+            , help
+                "Ed25519 secret key for signing merkle roots \
+                \(32 bytes, base16-encoded). When set, each \
+                \MerkleRootEntry includes a signature."
+            , metavar "HEX"
+            , reader str
+            , option
+            ]
+  where
+    decodeHex :: String -> Maybe ByteString
+    decodeHex s = case convertFromBase Base16 (packBS s) of
+        Left (_ :: String) -> Nothing
+        Right bs -> Just bs
+    packBS = BS.pack . map (fromIntegral . fromEnum)
+
 -- | Main options parser with YAML config file support
 optionsParser :: Parser Options
 optionsParser = withYamlConfig configFileOption optionsParserCore
@@ -300,6 +325,7 @@ optionsParserCore =
         <*> syncThresholdOption
         <*> genesisFileOption
         <*> byronGenesisFileOption
+        <*> signingKeyOption
   where
     mkOptions
         net
@@ -312,7 +338,8 @@ optionsParserCore =
         metrics
         threshold
         genesis
-        byronGenesis =
+        byronGenesis
+        signing =
             Options
                 { network = net
                 , connectionMode = connMode
@@ -325,4 +352,5 @@ optionsParserCore =
                 , syncThreshold = threshold
                 , genesisFile = genesis
                 , byronGenesisFile = byronGenesis
+                , signingKey = signing
                 }

--- a/lib/Cardano/UTxOCSMT/Signing.hs
+++ b/lib/Cardano/UTxOCSMT/Signing.hs
@@ -1,0 +1,55 @@
+{- |
+Module      : Cardano.UTxOCSMT.Signing
+Description : Ed25519 signing for merkle root attestations
+Copyright   : (c) Paolo Veronelli, 2026
+License     : Apache-2.0
+
+Signs @(blockHash, merkleRoot)@ tuples so institutions can
+attest the UTxO state at each chain point.
+
+Signing is optional: when no key is configured the service
+runs unsigned.
+-}
+module Cardano.UTxOCSMT.Signing
+    ( SigningConfig (..)
+    , parseSigningKey
+    , signMerkleRoot
+    , renderPublicKey
+    )
+where
+
+import CSMT.Hashes (Hash (..), renderHash)
+import Crypto.Error (CryptoFailable (..))
+import Crypto.PubKey.Ed25519 qualified as Ed25519
+import Data.ByteArray (convert)
+import Data.ByteString (ByteString)
+
+-- | Signing configuration: secret key + derived public key.
+data SigningConfig = SigningConfig
+    { sigSecretKey :: Ed25519.SecretKey
+    , sigPublicKey :: Ed25519.PublicKey
+    }
+
+-- | Parse a 32-byte Ed25519 secret key from raw bytes.
+parseSigningKey :: ByteString -> Maybe SigningConfig
+parseSigningKey bs = case Ed25519.secretKey bs of
+    CryptoPassed sk ->
+        let pk = Ed25519.toPublic sk
+        in  Just SigningConfig{sigSecretKey = sk, sigPublicKey = pk}
+    CryptoFailed _ -> Nothing
+
+{- | Sign @(blockHash, merkleRoot)@.
+The signed payload is the concatenation of the two
+32-byte hashes (64 bytes total).
+-}
+signMerkleRoot
+    :: SigningConfig -> Hash -> Hash -> ByteString
+signMerkleRoot SigningConfig{sigSecretKey, sigPublicKey} bh mr =
+    let payload = renderHash bh <> renderHash mr
+    in  convert
+            $ Ed25519.sign sigSecretKey sigPublicKey payload
+
+-- | Render the public key as raw bytes.
+renderPublicKey :: SigningConfig -> ByteString
+renderPublicKey SigningConfig{sigPublicKey} =
+    convert sigPublicKey


### PR DESCRIPTION
Closes #225

Optional Ed25519 signing of merkle root entries.

- `Signing` module: key parsing, signing, public key export
- `--signing-key` option (base16 Ed25519 secret key)
- `MerkleRootEntry` includes optional `signature` field
- `GET /signing-key` returns the public key (404 when unsigned)
- Without key, behavior unchanged (no signature, no endpoint)

Signed payload: `blockHash <> merkleRoot` (64 bytes, Ed25519 signature).