### PR TITLE
chore: bump haskell-mts to main HEAD (csmt-core extraction)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -26,8 +26,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/haskell-mts
-  tag: e54d9f3c790d07a9ae706397945da60c1a10c11e
-  --sha256: 03m6br7pqbn87z70baffbcrz4qvsc2qbwknv48nvvvpgyzkdg84i
+  tag: 9a510679075930bae812fea5f56b47789ce497ca
+  --sha256: 1cph1rdhyzk323qfxlrnr63mpgqich3rmaixwq1irvnk445ydchz
 
 source-repository-package
   type: git

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -78,6 +78,7 @@ library http
     , aeson
     , aeson-pretty
     , base                       <5
+    , base16-bytestring
     , bytestring
     , cardano-utxo-csmt:library
     , lens

--- a/http/Cardano/UTxOCSMT/HTTP/API.hs
+++ b/http/Cardano/UTxOCSMT/HTTP/API.hs
@@ -26,7 +26,7 @@ module Cardano.UTxOCSMT.HTTP.API
     )
 where
 
-import CSMT.Hashes (Hash, renderHash)
+import CSMT.Hashes (Hash, parseHash, renderHash)
 import Cardano.UTxOCSMT.Application.Metrics (Metrics)
 import Cardano.UTxOCSMT.HTTP.Base16 (decodeBase16Text)
 import Control.Lens ((&), (.~), (?~))
@@ -164,7 +164,10 @@ instance FromJSON MerkleRootEntry where
         parseHashBase16 txt =
             case decodeBase16Text txt of
                 Left err -> fail $ "Invalid base16 hash: " ++ err
-                Right h -> return h
+                Right bs -> case parseHash bs of
+                    Just h -> return h
+                    Nothing ->
+                        fail "Invalid hash length (expected 32 bytes)"
 
 instance ToJSON InclusionProofResponse where
     toJSON

--- a/http/Cardano/UTxOCSMT/HTTP/Base16.hs
+++ b/http/Cardano/UTxOCSMT/HTTP/Base16.hs
@@ -4,25 +4,29 @@ module Cardano.UTxOCSMT.HTTP.Base16
     , unsafeDecodeBase16Text
     ) where
 
-import Data.ByteArray (ByteArray, ByteArrayAccess)
-import Data.ByteArray.Encoding
-    ( Base (..)
-    , convertFromBase
-    , convertToBase
-    )
+import Data.ByteString (ByteString)
+import Data.ByteString.Base16 qualified as Base16
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 
--- | Encode a ByteString to Base16 Text
-encodeBase16Text :: ByteArrayAccess a => a -> T.Text
-encodeBase16Text = TE.decodeUtf8 . convertToBase Base16
+-- | Encode a 'ByteString' as Base16 'T.Text'.
+encodeBase16Text :: ByteString -> T.Text
+encodeBase16Text = TE.decodeUtf8 . Base16.encode
 
--- | Decode a Base16 Text to ByteString
-decodeBase16Text :: ByteArray a => T.Text -> Either String a
-decodeBase16Text = convertFromBase Base16 . TE.encodeUtf8
+-- | Decode a Base16 'T.Text' to a 'ByteString'.
+decodeBase16Text :: T.Text -> Either String ByteString
+decodeBase16Text txt =
+    case Base16.decode (TE.encodeUtf8 txt) of
+        Right bs -> Right bs
+        Left _ -> Left "invalid base16"
 
-unsafeDecodeBase16Text :: ByteArray a => T.Text -> a
+{- | Partial variant of 'decodeBase16Text'. Only safe when the
+caller has already validated the input (e.g. a constant or
+previously-encoded bytes).
+-}
+unsafeDecodeBase16Text :: T.Text -> ByteString
 unsafeDecodeBase16Text txt =
     case decodeBase16Text txt of
-        Left err -> error $ "unsafeDecodeBase16Text: invalid base16: " ++ err
+        Left err ->
+            error $ "unsafeDecodeBase16Text: " ++ err
         Right bs -> bs


### PR DESCRIPTION
## Summary

Bumps the `haskell-mts` pin to [`9a51067`](https://github.com/lambdasistemi/haskell-mts/commit/9a510679075930bae812fea5f56b47789ce497ca) — main HEAD at 2026-04-23. This is the first main commit that ships both WASM-safe sublibraries downstream consumers (`cardano-mpfs-client`) need:

- `mts:csmt-verify` (PR [#141](https://github.com/lambdasistemi/haskell-mts/pull/141)) — pure-Haskell CSMT inclusion/exclusion verifier.
- `mts:mpf-write` (PR [#147](https://github.com/lambdasistemi/haskell-mts/pull/147)) — pure-Haskell MPF verifier with Aiken-parity inclusion + exclusion.

## What broke

Between our old pin (`e54d9f3c`) and the new one, `CSMT.Core.Hash.Hash` was extracted into the `csmt-core` sublibrary and in that move lost its `ByteArray` / `ByteArrayAccess` derivings. This broke `Cardano.UTxOCSMT.HTTP.Base16.decodeBase16Text`'s polymorphic `ByteArray a => Text -> Either String a` signature at the one call site that wanted a `Hash` back.

## Fix

- Rewrote `http/Cardano/UTxOCSMT/HTTP/Base16.hs` to use `Data.ByteString.Base16` directly. Signature now: `decodeBase16Text :: Text -> Either String ByteString` / `encodeBase16Text :: ByteString -> Text`.
- At the one `Hash`-shaped call site in `http/Cardano/UTxOCSMT/HTTP/API.hs:163`, wrap the decoded bytes via `CSMT.Hashes.parseHash`, which also enforces the 32-byte length check.
- `application/.../Run/Query.hs` already consumed the decoded bytes as `ByteString`, so no change at that site.
- Added `base16-bytestring` to `library http`'s `build-depends`.

## Why now

[lambdasistemi/cardano-mpfs-offchain#226](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/226) needs `mts:csmt-verify` + `mts:mpf-write` to replay proofs on the client side. Without this bump, the MPFS offchain build fails at `cardano-utxo-csmt:lib:http` before reaching the new code.

## Test plan

- [x] `cabal build -O0 all` — green
- [x] `cabal test -O0 cardano-utxo-csmt:unit-tests` — 61/61 green
- [ ] Downstream verification on `cardano-mpfs-offchain` (issue [#226](https://github.com/lambdasistemi/cardano-mpfs-offchain/issues/226)) — pin to the merged SHA once this lands.