### PR TITLE
docs: align documentation with current code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Repository Agent Guide
+
+## What this repo is
+
+`cardano-utxo-csmt` is a Haskell HTTP service that follows the Cardano
+chain, maintains a Compact Sparse Merkle Tree (CSMT) over the live UTxO
+set in a local RocksDB database, and serves cryptographic inclusion
+proofs and historical Merkle roots over a REST API. It connects to a node
+either node-to-node (TCP: ChainSync headers + BlockFetch) or
+node-to-client (Unix socket: ChainSync full blocks). The repo is a single
+Cabal package with internal libraries (`library`, `http`, `application`)
+and three executables (`cardano-utxo`, `db-query`, `cardano-utxo-swagger`).
+
+## How to work here
+
+The project uses Nix and a `justfile`. Enter the dev shell with
+`nix develop`, then use `just`:
+
+- Build: `just build` (`cabal build all --enable-tests --enable-benchmarks`)
+- Unit tests: `just unit`
+- Database tests: `just database`
+- Format: `just format` (fourmolu + cabal-fmt + nixfmt)
+- Lint: `just hlint`
+- Full local CI gate: `just CI`
+- Regenerate the OpenAPI doc: `just update-swagger` (writes `docs/assets/swagger.json`)
+- Serve docs locally: `just serve-docs`
+
+Integration / end-to-end suites (`just integration`, `just e2e`,
+`just e2e-n2n`, `just e2e-genesis`) need a `cardano-node` and Docker.
+Nix flake outputs: `.#cardano-utxo`, `.#cardano-utxo-swagger`,
+`.#unit-tests`, `.#database-tests`, `.#bench`, `.#e2e-tests`,
+`.#docker-image`. Scope conventions: Haskell sources are under `lib/`,
+`http/`, `application/`, and `executables/`; this is **not** a `src/`
+layout.
+
+Run the service locally against Docker-hosted nodes with
+`run/cardano-utxo.sh <preview|preprod|mainnet>`.
+
+## Skills
+
+Activatable procedures live under `skills/`. Load the one whose
+description matches your task:
+
+- `skills/cardano-utxo-csmt-guide/` — orient in this repository: the code
+  map, exact build/test/run commands, where chain-sync / CSMT / RocksDB /
+  HTTP logic lives, the CLI options and REST endpoints as implemented,
+  and where the answers to common user questions are documented.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,29 +1,7 @@
-# cardano-utxo-csmt-issue-151 Development Guidelines
+# CLAUDE.md
 
-Auto-generated from all feature plans. Last updated: 2026-03-27
+This project's agent guidance lives in [AGENTS.md](AGENTS.md) (portable,
+read by any agent) and in `skills/cardano-utxo-csmt-guide/SKILL.md`
+(activatable repository guide).
 
-## Active Technologies
-
-- Haskell (GHC 9.8.4) + `stm` (TVar, STM), `servant-server` (HTTP API), `rocksdb-kv-transactions` (002-await-value)
-
-## Project Structure
-
-```text
-src/
-tests/
-```
-
-## Commands
-
-# Add commands for Haskell (GHC 9.8.4)
-
-## Code Style
-
-Haskell (GHC 9.8.4): Follow standard conventions
-
-## Recent Changes
-
-- 002-await-value: Added Haskell (GHC 9.8.4) + `stm` (TVar, STM), `servant-server` (HTTP API), `rocksdb-kv-transactions`
-
-<!-- MANUAL ADDITIONS START -->
-<!-- MANUAL ADDITIONS END -->
+Start at [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -3,28 +3,206 @@
 [![CI](https://github.com/lambdasistemi/cardano-utxo-csmt/actions/workflows/CI.yaml/badge.svg)](https://github.com/lambdasistemi/cardano-utxo-csmt/actions/workflows/CI.yaml)
 [![Documentation](https://github.com/lambdasistemi/cardano-utxo-csmt/actions/workflows/deploy-docs.yaml/badge.svg)](https://github.com/lambdasistemi/cardano-utxo-csmt/actions/workflows/deploy-docs.yaml)
 
-An HTTP service that maintains a Compact Sparse Merkle Tree (CSMT) over Cardano's UTxO set, enabling efficient cryptographic inclusion proofs.
+An HTTP service that maintains a Compact Sparse Merkle Tree (CSMT) over
+Cardano's UTxO set, enabling efficient cryptographic inclusion proofs.
 
-## Features
+## What is this
 
-- **Real-time Chain Sync**: Follows the blockchain via node-to-node protocol
-- **Merkle Proofs**: Generate inclusion proofs for any UTxO
-- **Multi-Era Support**: Byron through Conway
-- **Rollback Handling**: Graceful chain reorganization support
-- **REST API**: Simple HTTP interface with Swagger documentation
+`cardano-utxo-csmt` follows the Cardano chain, tracks the live UTxO set,
+and keeps a Compact Sparse Merkle Tree over it in a local RocksDB
+database. Every block updates the tree and produces a new Merkle root
+that commits to the entire UTxO set at that point.
+
+It connects to a Cardano node in one of two modes: node-to-node over TCP
+(ChainSync headers plus BlockFetch) or node-to-client over a Unix socket
+(ChainSync streaming full blocks). UTxO references are stored CBOR-encoded
+so the same representation works across all eras (Byron through Conway),
+and TxOuts are projected to the Conway era before storage. Chain
+reorganizations are handled by replaying stored inverse operations from
+rollback points.
+
+A REST API exposes the current sync metrics, historical Merkle roots, and
+on-demand inclusion proofs for individual UTxOs. The service bootstraps a
+fresh database from genesis (Shelley, plus optional Byron `nonAvvmBalances`)
+and then syncs every block from Origin.
+
+The repository is a single Haskell package (`cardano-utxo-csmt`) with
+several internal libraries and three executables: the `cardano-utxo`
+service, a `db-query` debug tool, and a `cardano-utxo-swagger` OpenAPI
+emitter.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Client[HTTP Client]
+    subgraph Node [Cardano Node]
+        N2N[ChainSync + BlockFetch<br/>node-to-node TCP]
+        N2C[ChainSync full blocks<br/>node-to-client socket]
+    end
+    subgraph Service [cardano-utxo-csmt]
+        Follower[Chain follower<br/>headers + blocks]
+        Processor[UTxO extraction<br/>spends + creates]
+        Tree[CSMT engine<br/>Merkle root]
+        subgraph Store [RocksDB]
+            KV[(kv: UTxOs)]
+            CSMT[(csmt: tree nodes)]
+            RB[(rollbacks)]
+            Internal[(config + journal + metrics)]
+        end
+        HTTP["HTTP API<br/>/ready /metrics /proof<br/>/merkle-roots /await<br/>/utxos-by-address"]
+    end
+    N2N -->|blocks| Follower
+    N2C -->|blocks| Follower
+    Follower --> Processor
+    Processor --> Tree
+    Tree --> Store
+    HTTP --> Store
+    Client -->|REST| HTTP
+```
+
+In node-to-node mode the ChainSync client receives headers and the
+BlockFetch client retrieves full blocks; in node-to-client mode a single
+ChainSync client streams full blocks over the socket. Either way, each
+block's spends and creates are applied to the `kv` (UTxO) and `csmt`
+(tree) column families, rollback points are recorded, and a new Merkle
+root is computed. See [docs/architecture.md](docs/architecture.md) for
+the full data flow and the database schema in
+[docs/database-schema.md](docs/database-schema.md).
+
+## Install
+
+The service is distributed as a Nix flake. Pre-built artifacts (Docker
+image, AppImage, RPM, DEB, and platform tarballs) are produced by CI and
+attached to GitHub releases.
+
+```bash
+# Run directly from the flake (recommended)
+nix run github:lambdasistemi/cardano-utxo-csmt -- --help
+
+# Optional: enable the binary cache to avoid rebuilding dependencies
+nix shell nixpkgs#cachix -c cachix use paolino
+```
+
+Docker images are published to
+`ghcr.io/lambdasistemi/cardano-utxo-csmt/cardano-utxo`. The flake builds
+for `x86_64-linux` and `aarch64-darwin`.
+
+## Quickstart
+
+Run against a node on preprod, bootstrapping from genesis. This example
+uses node-to-client (`--socket-path`); use `--node-name`/`--node-port`
+instead for node-to-node.
+
+```bash
+nix run github:lambdasistemi/cardano-utxo-csmt -- \
+  --network preprod \
+  --socket-path /path/to/node.socket \
+  --genesis-file /path/to/shelley-genesis.json \
+  --byron-genesis-file /path/to/byron-genesis.json \
+  --db-path /tmp/csmt-db \
+  --api-port 8080
+
+# Once running, check readiness and query a proof:
+curl http://localhost:8080/ready
+curl http://localhost:8080/proof/<txId>/<txIx>
+```
+
+`--genesis-file` (Shelley) is always required: it provides the security
+parameter `k`, network magic, and epoch slots, and seeds the initial
+UTxO set on a fresh database. `--byron-genesis-file` is optional but
+recommended when syncing from Origin so that blocks spending Byron
+genesis UTxOs do not fail. See
+[docs/getting-started.md](docs/getting-started.md) for the full option
+list.
+
+## Usage
+
+### Service (`cardano-utxo`)
+
+Key command-line options (run `cardano-utxo --help` for the complete
+list; all `conf` options may also be set via a YAML `--config-file`):
+
+| Option | Description |
+|--------|-------------|
+| `--network`, `-n` | `mainnet`, `preprod`, `preview`, or `devnet` (default: `mainnet`) — selects default peer node |
+| `--socket-path` | Node Unix socket path (node-to-client mode) |
+| `--node-name`, `-s` / `--node-port`, `-p` | Peer node host and port (node-to-node mode) |
+| `--db-path`, `-d` | RocksDB database directory (required) |
+| `--genesis-file` | Path to `shelley-genesis.json` (required) |
+| `--byron-genesis-file` | Path to `byron-genesis.json` (optional, for genesis bootstrap) |
+| `--api-port` | Port for the REST API server |
+| `--api-docs-port` | Port for the Swagger UI documentation server |
+| `--log-path`, `-l` | Log file path (logs to stdout if omitted) |
+| `--config-file`, `-c` | YAML configuration file |
+| `--headers-queue-size`, `-q` | Header queue size (default: 10) |
+| `--sync-threshold` | Max slots behind tip to be considered synced (default: 100) |
+| `--enable-metrics-reporting` | Emit metrics on stdout |
+
+### REST API
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /ready` | Sync readiness (`ready`, `tipSlot`, `processedSlot`, `slotsBehind`) |
+| `GET /metrics` | Current sync metrics (JSON) |
+| `GET /metrics/prometheus` | Metrics in Prometheus exposition format |
+| `GET /merkle-roots` | Historical Merkle roots by block |
+| `GET /proof/:txId/:txIx` | Inclusion proof for a UTxO |
+| `GET /utxos-by-address/:address` | UTxOs at an address |
+| `GET /await/:txId/:txIx?timeout=N` | Block until a UTxO appears (HTTP 408 on timeout) |
+| `GET /api-docs/swagger-ui` | Swagger UI (when `--api-docs-port` is set) |
+
+Endpoints other than `/ready`, `/metrics`, and `/metrics/prometheus`
+return HTTP 503 until the service reports synced.
+
+### Debug tool (`db-query`)
+
+```bash
+db-query --db-path /tmp/csmt-db --txid <64-hex-txid> [--index N]
+```
+
+Looks up a TxIn in the `kv` column family; with `--index` omitted it
+probes indices 0–3.
+
+### Local run helper
+
+`run/cardano-utxo.sh <preview|preprod|mainnet>` wraps the service against
+local Docker-hosted nodes using the matching `config/<network>.yaml`. See
+[run/README.md](run/README.md).
 
 ## Documentation
 
-Full documentation available at **[lambdasistemi.github.io/cardano-utxo-csmt](https://lambdasistemi.github.io/cardano-utxo-csmt/)**
+Full documentation: **[lambdasistemi.github.io/cardano-utxo-csmt](https://lambdasistemi.github.io/cardano-utxo-csmt/)**
 
 - [Getting Started](https://lambdasistemi.github.io/cardano-utxo-csmt/getting-started/)
 - [Architecture](https://lambdasistemi.github.io/cardano-utxo-csmt/architecture/)
+- [Database Schema](https://lambdasistemi.github.io/cardano-utxo-csmt/database-schema/)
 - [API Reference](https://lambdasistemi.github.io/cardano-utxo-csmt/swagger-ui/)
 
-## Roadmap
+For AI agents, start at [AGENTS.md](AGENTS.md).
 
-See [Milestones](https://github.com/lambdasistemi/cardano-utxo-csmt/milestones) for planned releases and progress.
+## Development
+
+The project uses Nix and a `justfile`. Enter the dev shell with
+`nix develop`, then:
+
+```bash
+just build        # cabal build all --enable-tests --enable-benchmarks
+just unit         # unit-tests suite
+just database     # database-tests suite (RocksDB-backed)
+just format       # fourmolu + cabal-fmt + nixfmt
+just hlint        # hlint
+just CI           # full local CI gate
+just serve-docs   # mkdocs serve on a free port
+just update-swagger  # regenerate docs/assets/swagger.json
+```
+
+Integration and end-to-end suites (`just integration`, `just e2e`,
+`just e2e-n2n`, `just e2e-genesis`) require a `cardano-node` and Docker.
+The Nix flake exposes the corresponding outputs (`.#cardano-utxo`,
+`.#unit-tests`, `.#database-tests`, `.#bench`, `.#e2e-tests`,
+`.#docker-image`).
 
 ## License
 
-Apache-2.0
+Apache-2.0. See [LICENSE](LICENSE).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,11 +13,12 @@ flowchart LR
     subgraph Service [UTxO CSMT Service]
         CS_C[ChainSync Client]
         BF_C[BlockFetch Client]
-        HTTP[HTTP Server<br>/metrics<br>/proof/:id<br>/merkle-roots]
+        HTTP["HTTP Server<br>/ready /metrics<br>/merkle-roots /proof<br>/utxos-by-address /await"]
         subgraph DB [Database — RocksDB]
-            UTxOs
+            KV[kv: UTxOs]
             CSMT
-            Rollbacks[Rollback Points]
+            Rollbacks
+            Internal[config / journal / metrics]
         end
     end
     Client[HTTP Client]
@@ -29,17 +30,29 @@ flowchart LR
     Client --> HTTP
 ```
 
+The diagram shows **node-to-node** mode, where a ChainSync client follows
+headers and a BlockFetch client retrieves full blocks. In
+**node-to-client** mode (`--socket-path`) a single ChainSync client
+streams full blocks over a Unix socket and no separate BlockFetch client
+is used; everything downstream of block arrival is identical.
+
 ## Components
 
 ### Chain Synchronization
 
-The service connects to a Cardano node using the node-to-node protocol:
+The service connects to a Cardano node in one of two modes, selected by
+the command-line options:
 
-- **ChainSync Client**: Follows the chain tip, receiving block headers
-- **BlockFetch Client**: Retrieves full block data for processing
-- **KeepAlive**: Maintains the connection
+- **Node-to-node** (`--node-name` + `--node-port`): a ChainSync client
+  follows the chain tip receiving block headers, a BlockFetch client
+  retrieves full block data, and KeepAlive maintains the connection.
+  Headers are queued (`--headers-queue-size`) and blocks are fetched in
+  batches for efficiency.
+- **Node-to-client** (`--socket-path`): a single ChainSync client streams
+  full blocks over the node's local Unix socket; there is no separate
+  BlockFetch client.
 
-Headers are queued and blocks are fetched in batches for efficiency.
+Both modes feed the same UTxO processing pipeline.
 
 ### UTxO Processing
 
@@ -62,23 +75,37 @@ The Merkle root changes with each block, providing a cryptographic commitment to
 
 ### Database (RocksDB)
 
-Three column families store different data:
+Six column families store different data:
 
 | Column | Key | Value |
 |--------|-----|-------|
-| UTxOs | TxIn (CBOR) | TxOut (CBOR) |
-| CSMT | Path | Hash + Jump |
-| Rollback Points | Slot | Changes for rollback |
+| `kv` | TxIn (CBOR) | TxOut (CBOR) |
+| `csmt` | Path | Hash + Jump |
+| `rollbacks` | Slot (or sentinel) | Inverse operations for rollback |
+| `config` | `"app_config"` | Serialised checkpoint/config |
+| `journal` | TxIn | Pending entry for KVOnly-mode replay |
+| `metrics` | counter name | Journal size counter |
 
-Rollback points enable chain reorganization handling without full recomputation.
+Rollback points enable chain reorganization handling without full
+recomputation. The `journal` and `metrics` columns support crash
+recovery during bulk replay; see
+[Database Schema](database-schema.md) for the full CDDL of the
+user-facing columns.
 
 ### HTTP API
 
 The REST API provides:
 
-- `GET /metrics` - Sync progress and performance metrics
-- `GET /merkle-roots` - Historical merkle roots by slot
+- `GET /ready` - Sync readiness for orchestration
+- `GET /metrics` - Sync progress and performance metrics (JSON)
+- `GET /metrics/prometheus` - Metrics in Prometheus exposition format
+- `GET /merkle-roots` - Historical merkle roots by block
 - `GET /proof/:txId/:txIx` - Inclusion proof for a UTxO
+- `GET /utxos-by-address/:address` - UTxOs at an address
+- `GET /await/:txId/:txIx?timeout=N` - Block until a UTxO appears
+
+All endpoints except `/ready`, `/metrics`, and `/metrics/prometheus`
+return HTTP 503 until the service reports synced.
 
 ## Data Flow
 
@@ -102,8 +129,10 @@ If rollback exceeds stored history (truncation), the service restarts sync from 
 
 ### Genesis Bootstrap
 
-The service bootstraps by reading the initial UTxO set from Byron and Shelley
-genesis files, then syncing all blocks from Origin. Key optimizations:
+On a fresh database the service bootstraps by reading the initial UTxO
+set from the Shelley genesis file (always required) and, when provided,
+the Byron genesis file's `nonAvvmBalances`, then syncing all blocks from
+Origin. Key optimizations:
 
 1. **Era projection**: Project all TxOut to Conway era before storage
 2. **Change reduction**: Reduce UTxO changes inline as ChainSync writes to the buffer,

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,8 +1,8 @@
 # Database Schema
 
-The application stores data in RocksDB using four column families.
-All structured values are CBOR-encoded. The schema below is specified
-in [CDDL](https://www.rfc-editor.org/rfc/rfc8610) (RFC 8610).
+The application opens six RocksDB column families. The four below carry
+the persistent state; the structured values are CBOR-encoded and
+specified in [CDDL](https://www.rfc-editor.org/rfc/rfc8610) (RFC 8610).
 
 ## Column Families
 
@@ -12,6 +12,14 @@ in [CDDL](https://www.rfc-editor.org/rfc/rfc8610) (RFC 8610).
 | `csmt` | [Key](#key) | [Indirect](#indirect) |
 | `rollbacks` | [WithSentinel](#withsentinel) | [RollbackPoint](#rollbackpoint) |
 | `config` | UTF-8 literal `"app_config"` | Serialise-encoded tuple |
+
+Two further column families support crash recovery during bulk replay
+(KVOnly mode) and are not part of the persisted query state:
+
+| Column Family | Key | Value |
+|---------------|-----|-------|
+| `journal` | raw bytes (UTxO reference) | raw bytes (pending entry) |
+| `metrics` | counter name | decimal-string journal size counter |
 
 ## CDDL
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,9 +4,11 @@ This guide covers installation, configuration and usage of the Cardano UTxO CSMT
 
 ## Prerequisites
 
-- A trusted running Cardano node with secure node-to-node protocol access
-- Network connectivity to the node's port (default: 3001)
-- Shelley and Byron genesis files for your network
+- A trusted running Cardano node, reachable either over node-to-node TCP
+  (`--node-name` + `--node-port`, e.g. mainnet relay port 3001) or over
+  its local node-to-client Unix socket (`--socket-path`)
+- The Shelley genesis file for your network (always required); the Byron
+  genesis file as well if you want to bootstrap from Origin
 
 ## Installation
 
@@ -26,17 +28,19 @@ nix run github:lambdasistemi/cardano-utxo-csmt -- \
   --api-port 8080
 ```
 
-This will:
+On a fresh database this will:
 
-1. Read initial UTxOs from both Byron and Shelley genesis files
+1. Read initial UTxOs from the Shelley genesis file (and the Byron
+   genesis file's `nonAvvmBalances` when `--byron-genesis-file` is given)
 2. Insert them into the CSMT database
 3. Start chain sync from Origin
 
-!!! warning
-    Starting without `--genesis-file` and `--byron-genesis-file` will crash
-    on the first block that spends a genesis UTxO, because the UTxO won't
-    exist in the database yet. Always provide genesis files when syncing
-    from Origin.
+!!! note
+    `--genesis-file` (Shelley) is **always required** — the service reads
+    the security parameter `k`, network magic, and epoch slots from it and
+    will not start without it. When syncing from Origin, also pass
+    `--byron-genesis-file`; otherwise the first block that spends a Byron
+    genesis UTxO will fail because that UTxO is not in the database.
 
 The genesis files are part of the node configuration. For a local NixOS node
 they are typically found alongside the node config (e.g.
@@ -46,15 +50,23 @@ they are typically found alongside the node config (e.g.
 
 | Option | Description |
 |--------|-------------|
-| `--network` | Network: `mainnet`, `preprod`, `preview` (default: mainnet) |
-| `--node-name` | Override peer node hostname |
-| `--node-port` | Override peer node port |
-| `--socket-path` | Node-to-Client Unix socket path |
-| `--db-path` | RocksDB database path (required) |
+| `--network`, `-n` | Network: `mainnet`, `preprod`, `preview`, `devnet` (default: mainnet) — selects the default peer node |
+| `--node-name`, `-s` | Peer node hostname (node-to-node mode) |
+| `--node-port`, `-p` | Peer node port (node-to-node mode) |
+| `--socket-path` | Node-to-client Unix socket path |
+| `--db-path`, `-d` | RocksDB database path (required) |
+| `--genesis-file` | Path to `shelley-genesis.json` (required) |
+| `--byron-genesis-file` | Path to `byron-genesis.json` for genesis bootstrap (recommended) |
 | `--api-port` | HTTP API port for REST endpoints |
-| `--api-docs-port` | HTTP port for Swagger UI documentation |
-| `--genesis-file` | Path to shelley-genesis.json for genesis bootstrap (required) |
-| `--byron-genesis-file` | Path to byron-genesis.json for genesis bootstrap (recommended) |
+| `--api-docs-port` | HTTP port for the Swagger UI documentation server |
+| `--config-file`, `-c` | YAML configuration file (`conf` options may be set here) |
+| `--log-path`, `-l` | Log file path (logs to stdout if omitted) |
+| `--headers-queue-size`, `-q` | Header queue size (default: 10) |
+| `--sync-threshold` | Max slots behind tip to be considered synced (default: 100) |
+| `--enable-metrics-reporting` | Emit metrics on stdout |
+
+Provide exactly one connection mode: either `--socket-path` (node-to-client)
+or `--node-name` + `--node-port` (node-to-node).
 
 ## Verifying the Service
 
@@ -66,10 +78,12 @@ curl http://localhost:8080/ready
 
 # Check metrics
 curl http://localhost:8080/metrics
-
-# View API documentation
-open http://localhost:8080/api-docs/swagger-ui
 ```
+
+The Swagger UI is served by a separate documentation server on
+`--api-docs-port`. Start the service with, for example,
+`--api-docs-port 8081`, then open
+`http://localhost:8081/api-docs/swagger-ui`.
 
 ## Next Steps
 

--- a/run/README.md
+++ b/run/README.md
@@ -73,4 +73,4 @@ Once running:
 
 - **Metrics**: `http://localhost:{API_PORT}/metrics`
 - **Ready**: `http://localhost:{API_PORT}/ready`
-- **Swagger**: `http://localhost:{API_DOCS_PORT}/`
+- **Swagger**: `http://localhost:{API_DOCS_PORT}/api-docs/swagger-ui`

--- a/skills/cardano-utxo-csmt-guide/SKILL.md
+++ b/skills/cardano-utxo-csmt-guide/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: cardano-utxo-csmt-guide
+description: >-
+  Orientation guide for the cardano-utxo-csmt repository — a Haskell HTTP
+  service that maintains a Compact Sparse Merkle Tree (CSMT) over Cardano's
+  UTxO set in RocksDB and serves inclusion proofs. Load this when working in
+  cardano-utxo-csmt: building or testing it (just build, just unit, just
+  database, nix run .#cardano-utxo), understanding chain sync (node-to-node
+  ChainSync + BlockFetch, or node-to-client over a Unix socket via
+  --socket-path), the CSMT engine, the RocksDB column families (kv, csmt,
+  rollbacks, config, journal, metrics), genesis bootstrap (--genesis-file,
+  --byron-genesis-file), the CLI options (--network, --db-path, --api-port,
+  --api-docs-port, --sync-threshold, --headers-queue-size), or the REST API
+  (/ready, /metrics, /metrics/prometheus, /merkle-roots, /proof, /await,
+  /utxos-by-address). Also for questions about the cardano-utxo, db-query,
+  and cardano-utxo-swagger executables, rollback handling, the Conway-era
+  TxOut projection, or modules under Cardano.UTxOCSMT.*.
+---
+
+# cardano-utxo-csmt guide
+
+A single Cabal package (`cardano-utxo-csmt`) building internal libraries
+plus three executables. It follows the Cardano chain, tracks the UTxO
+set, maintains a CSMT over it in RocksDB, and serves proofs over HTTP.
+
+## Repository map
+
+| Path | Purpose |
+|------|---------|
+| `lib/Cardano/UTxOCSMT/` | Core library (`library` component): chain sync, UTxO processing, CSMT-over-RocksDB, options, metrics |
+| `lib/.../Application/ChainSync.hs`, `BlockFetch.hs`, `KeepAlive.hs` | Node-to-node protocol clients |
+| `lib/.../Application/ChainSyncN2C.hs` | Node-to-client (full-block) chain sync |
+| `lib/.../Application/Options.hs` | CLI/YAML option parser (`opt-env-conf`) |
+| `lib/.../Application/Database/` | RocksDB backend, column codecs, rollback points, query implementation |
+| `lib/.../Bootstrap/Genesis.hs` | Reads Shelley/Byron genesis (params + initial UTxOs) |
+| `lib/.../Ouroboros/` | Ouroboros network connection, codecs, types |
+| `http/Cardano/UTxOCSMT/HTTP/` | Servant API (`API.hs`), server (`Server.hs`), Swagger (`Swagger.hs`) |
+| `application/Cardano/UTxOCSMT/Application/Run/` | Wiring: `Main.hs`, `Setup.hs` (genesis/checkpoint), `Config.hs` (DB schema), `Query.hs` (endpoint handlers) |
+| `executables/chainsync/main.hs` | `cardano-utxo` service entry point (calls `Run.Main.main`) |
+| `executables/db-query/main.hs` | `db-query` debug tool |
+| `executables/swagger/main.hs` | `cardano-utxo-swagger` (prints OpenAPI JSON) |
+| `test/`, `database-test/`, `integration-test/`, `e2e-test/` | hspec suites |
+| `bench/` | criterion benchmarks |
+| `config/<network>.yaml` | Default peer node per network |
+| `run/cardano-utxo.sh` | Local run helper against Docker nodes |
+| `docs/`, `mkdocs.yml` | MkDocs site (getting-started, architecture, database-schema, swagger) |
+
+## Build, test, run
+
+Inside `nix develop` (or with `cabal` directly):
+
+```bash
+just build            # cabal build all --enable-tests --enable-benchmarks
+just unit             # unit-tests suite
+just database         # database-tests (RocksDB-backed)
+just format           # fourmolu + cabal-fmt + nixfmt
+just hlint            # hlint
+just CI               # full local gate (build, unit, fmt, hlint, swagger, diagrams)
+just update-swagger   # regenerate docs/assets/swagger.json
+just serve-docs       # mkdocs serve on a free port
+
+nix run .#cardano-utxo -- --help          # service
+nix run .#cardano-utxo-swagger            # print OpenAPI JSON
+nix build .#docker-image                  # OCI image
+```
+
+Integration/E2E (`just integration`, `just e2e`, `just e2e-n2n`,
+`just e2e-genesis`) need a `cardano-node` and Docker.
+
+## Navigating the code
+
+- **Entry point:** `executables/chainsync/main.hs` → `Run.Main.main`
+  (`application/.../Run/Main.hs`). That module wires options, the tracer
+  pipeline, RocksDB, genesis setup, the HTTP servers, and the chain
+  follower; it dispatches on `ConnectionMode` to `application` (N2N) or
+  `applicationN2C` (N2C).
+- **Connection modes:** defined in `Application/Options.hs`
+  (`ConnectionMode = N2N {..} | N2C {..}`). `--socket-path` selects N2C;
+  `--node-name` + `--node-port` select N2N.
+- **CSMT / RocksDB:** column families and codecs are in
+  `Application/Database/Implementation/Columns.hs`; the physical CFs are
+  opened in `Run/Config.hs` `withRocksDB` (kv, csmt, config, journal,
+  metrics, rollbacks). Rollback encoding is in
+  `Database/Implementation/RollbackPoint.hs`.
+- **HTTP surface:** the Servant API type is in `http/.../HTTP/API.hs`;
+  handlers and the synced-gate (HTTP 503) live in `http/.../HTTP/Server.hs`;
+  the query implementations are in `application/.../Run/Query.hs`.
+- **Genesis bootstrap:** `Run/Setup.hs` (`setupDB`) plus
+  `Bootstrap/Genesis.hs`. Shelley genesis is always read for `k`, network
+  magic, and epoch slots; Byron `nonAvvmBalances` are added when
+  `--byron-genesis-file` is given.
+
+## Using cardano-utxo-csmt
+
+Run the service (node-to-client example, bootstrapping from genesis):
+
+```bash
+nix run .#cardano-utxo -- \
+  --network preprod \
+  --socket-path /path/to/node.socket \
+  --genesis-file /path/to/shelley-genesis.json \
+  --byron-genesis-file /path/to/byron-genesis.json \
+  --db-path /tmp/csmt-db \
+  --api-port 8080 --api-docs-port 8081
+```
+
+REST endpoints (all but `/ready` and the `/metrics*` pair return 503
+until synced):
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /ready` | `{ready, tipSlot, processedSlot, slotsBehind}` |
+| `GET /metrics` | sync metrics (JSON) |
+| `GET /metrics/prometheus` | Prometheus exposition format |
+| `GET /merkle-roots` | historical Merkle roots by block |
+| `GET /proof/:txId/:txIx` | inclusion proof for a UTxO |
+| `GET /utxos-by-address/:address` | UTxOs at an address |
+| `GET /await/:txId/:txIx?timeout=N` | wait for a UTxO (HTTP 408 on timeout) |
+
+Swagger UI is served on `--api-docs-port` at `/api-docs/swagger-ui`.
+Inspect the database directly with
+`db-query --db-path <dir> --txid <64-hex> [--index N]`.
+
+## Answering questions
+
+- "What is this / what does it do?" → README **What is this**;
+  `docs/index.md`.
+- "How do I install / run it?" → README **Install** / **Quickstart**;
+  `docs/getting-started.md`; `run/README.md` for the local helper.
+- "What CLI flags exist?" → README **Usage** and
+  `docs/getting-started.md`; ground truth is
+  `lib/Cardano/UTxOCSMT/Application/Options.hs`.
+- "What REST endpoints exist?" → README **Usage**;
+  `docs/architecture.md` (HTTP API); ground truth is
+  `http/Cardano/UTxOCSMT/HTTP/API.hs` and the generated
+  `docs/assets/swagger.json`.
+- "How is data stored?" → `docs/database-schema.md` (CDDL); ground truth
+  is `Database/Implementation/Columns.hs` and `Run/Config.hs`.
+- "How does sync / rollback / bootstrap work?" →
+  `docs/architecture.md`; ground truth is `Run/Main.hs`, `Run/Setup.hs`,
+  and the `Application/ChainSync*` modules.
+- Always verify a claim against the cited source file before stating it;
+  the docs aim to track the code but the code is authoritative.


### PR DESCRIPTION
## Summary

Documentation review of `cardano-utxo-csmt` against the current state of
the code. Docs-only changes (README, `docs/**`, `run/README.md`, plus a
new agent layer). No code, tests, CI, flake, or justfile touched.

## What was inaccurate

Verified every factual claim against the source:

- **Column families.** `docs/architecture.md` listed **three** column
  families (UTxOs / CSMT / Rollback Points). The service actually opens
  **six** (`kv`, `csmt`, `config`, `journal`, `metrics`, `rollbacks`) —
  see `Run/Config.hs` `withRocksDB` and `Database/Implementation/Columns.hs`.
  `docs/database-schema.md` documented four; added the `journal`/`metrics`
  recovery columns.
- **REST endpoints.** Docs and the architecture diagram showed only
  `/metrics`, `/merkle-roots`, `/proof/:txId/:txIx`. The API
  (`http/.../HTTP/API.hs`, confirmed by `docs/assets/swagger.json`)
  actually exposes seven: `/ready`, `/metrics`, `/metrics/prometheus`,
  `/merkle-roots`, `/proof/:txId/:txIx`, `/utxos-by-address/:address`,
  `/await/:txId/:txIx`. Documented the synced-gate (HTTP 503) behaviour.
- **Connection modes.** Docs described only node-to-node. The code
  (`Application/Options.hs` `ConnectionMode`, dispatched in `Run/Main.hs`)
  supports both node-to-node (`--node-name`/`--node-port`) and
  node-to-client (`--socket-path`). Both modes are now documented and
  drawn.
- **Genesis requirement.** `getting-started.md` implied `--genesis-file`
  was optional ("starting without … will crash"). It is always required
  (`Options.hs` `genesisFileOption`; `Run/Setup.hs` reads `k`, network
  magic, epoch slots from it). Byron genesis remains optional. Reframed.
- **Missing CLI options.** Added `--config-file`, `--log-path`,
  `--headers-queue-size`, `--sync-threshold`, `--enable-metrics-reporting`,
  and the `devnet` network, all from `Application/Options.hs`.
- **Swagger UI URL.** `getting-started.md` and `run/README.md` pointed at
  the wrong port/path. The Swagger UI is served by a separate server on
  `--api-docs-port` at `/api-docs/swagger-ui` (`Run/Main.hs`,
  `HTTP/Server.hs`).

## What changed

- **README** restructured to the standard section order (What is this /
  Architecture / Install / Quickstart / Usage / Documentation /
  Development / License) with a verified mermaid architecture diagram and
  full, code-accurate CLI + REST tables.
- **docs/architecture.md, getting-started.md, database-schema.md,
  run/README.md** corrected as above.
- **Agent layer (new):** `AGENTS.md` at the root and
  `skills/cardano-utxo-csmt-guide/SKILL.md` (agentskills.io layout). The
  auto-generated `CLAUDE.md` (which described a non-existent `src/tests`
  layout) is now a thin pointer to `AGENTS.md`.

## How it was verified

- Read the source for every claim: `Options.hs`, `HTTP/API.hs`,
  `HTTP/Server.hs`, `Run/Main.hs`, `Run/Setup.hs`, `Run/Config.hs`,
  `Database/Implementation/Columns.hs`; cross-checked endpoints against
  `docs/assets/swagger.json`.
- Mermaid diagrams validated node-by-node and edge-by-edge against the
  code (connection modes, column families, endpoints).
- `mkdocs build` succeeds (non-strict). `--strict` aborts on two
  **pre-existing** warnings in `presentation/` (the `README.md` vs
  `index.html` URL conflict and a `slides.md` link to the Marp-generated
  `index.html`), both in files this PR does not touch.

## Note for maintainers (out of scope here)

`CHANGELOG.md` currently describes a Docker container-logs API ("end-point
to list containers", "streaming logs of a container") — unrelated to this
project. Left untouched to avoid a wholesale rewrite; flagging for a
follow-up.
