### PR TITLE
fix(api): key roots/proofs by full chain point (slot, blockHash) (#238)

### DIFF
--- a/application/Cardano/UTxOCSMT/Application/Run/Query.hs
+++ b/application/Cardano/UTxOCSMT/Application/Run/Query.hs
@@ -22,7 +22,6 @@ where
 import CSMT.Hashes
     ( Hash
     , generateInclusionProof
-    , renderHash
     )
 import CSMT.Interface (FromKV (..), root)
 import CSMT.Proof.Exclusion
@@ -119,8 +118,8 @@ queryMerkleRoots (RunTransaction runTx) =
         case slot of
             Sentinel -> []
             Value (Network.Point Origin) -> []
-            Value (Network.Point (At Block{})) ->
-                [MerkleRootEntry{blockHash, merkleRoot}]
+            Value (Network.Point (At Block{blockPointSlot = slotNo})) ->
+                [MerkleRootEntry{slotNo, blockHash, merkleRoot}]
 
 {- | Retrieve the inclusion proof and UTxO value for a transaction input.
 
@@ -150,19 +149,17 @@ queryInclusionProof (RunTransaction runTx) txIdText txIx = do
         mTip <- queryTip Rollbacks
         pure $ do
             (out, proof') <- result
-            bh <- case mTip of
-                Just (Value pt@(Network.Point (At Block{}))) ->
-                    Just (slotHash pt)
+            (proofSlotNo, proofBlockHash) <- case mTip of
+                Just (Value pt@(Network.Point (At block@Block{}))) ->
+                    Just (blockPointSlot block, slotHash pt)
                 _ -> Nothing
             pure
                 InclusionProofResponse
                     { proofTxOut = encodeBase16Text $ toStrict out
                     , proofBytes =
                         Text.decodeUtf8 $ convertToBase Base16 proof'
-                    , proofBlockHash =
-                        Text.decodeUtf8
-                            $ convertToBase Base16
-                            $ renderHash bh
+                    , proofSlotNo
+                    , proofBlockHash
                     }
   where
     txIn = unsafeMkTxIn (toShort $ unsafeDecodeBase16Text txIdText) txIx

--- a/cardano-utxo-csmt.cabal
+++ b/cardano-utxo-csmt.cabal
@@ -85,6 +85,7 @@ library http
     , memory
     , mts:csmt
     , network
+    , ouroboros-network:api
     , servant-server
     , servant-swagger
     , servant-swagger-ui

--- a/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
+++ b/database-test/Cardano/UTxOCSMT/HTTP/ServerSpec.hs
@@ -60,7 +60,9 @@ import Codec.CBOR.Write qualified as CBOR
 import Control.Lens (lazy, prism', strict, view)
 import Control.Monad.IO.Class (liftIO)
 import Control.Tracer (nullTracer)
-import Data.Aeson (eitherDecode)
+import Data.Aeson (Value (..), eitherDecode)
+import Data.Aeson.Key (Key)
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteArray.Encoding
     ( Base (..)
     , convertFromBase
@@ -185,6 +187,10 @@ decodeBase16OrFail txt =
         Left err -> fail $ "Base16 decode error: " ++ err
         Right bs -> pure bs
 
+jsonObjectHasKey :: Key -> Value -> Bool
+jsonObjectHasKey key (Object object) = KeyMap.member key object
+jsonObjectHasKey _ _ = False
+
 servedRootForProof
     :: InclusionProofResponse
     -> [MerkleRootEntry]
@@ -194,13 +200,14 @@ servedRootForProof proof roots =
         Nothing ->
             fail
                 $ "No merkle root for proof block hash "
-                    ++ T.unpack (proofBlockHash proof)
+                    ++ T.unpack
+                        (encodeBase16Text $ renderHash $ proofBlockHash proof)
         Just rootHash ->
             pure $ renderHash rootHash
   where
     matchingBlockHash entry =
-        encodeBase16Text (renderHash (blockHash entry))
-            == proofBlockHash proof
+        slotNo entry == proofSlotNo proof
+            && blockHash entry == proofBlockHash proof
 
 -- | Concrete column type.
 type Cols =
@@ -394,8 +401,8 @@ queryTestMerkleRoots (RunTransaction runTx) =
         pure $ concatMap toEntry (reverse history)
   where
     toEntry (slot, RollbackPoint{rpMeta}) = case (slot, rpMeta) of
-        (Value _, Just (blockHash, merkleRoot)) ->
-            [MerkleRootEntry{blockHash, merkleRoot}]
+        (Value slotNo, Just (blockHash, merkleRoot)) ->
+            [MerkleRootEntry{slotNo, blockHash, merkleRoot}]
         _ -> []
 
 -- | Query inclusion proof for testing.
@@ -432,8 +439,8 @@ queryTestInclusionProof (RunTransaction runTx) actualKey _txIdText _txIx =
                 InclusionProofResponse
                     { proofTxOut = encodeBase16 $ BL.toStrict out
                     , proofBytes = encodeBase16Text proof'
-                    , proofBlockHash =
-                        encodeBase16Text $ renderHash blockHash
+                    , proofSlotNo = tipSlot
+                    , proofBlockHash = blockHash
                     }
 
 prefixedCSMTContext :: CSMTContext Hash BL.ByteString BL.ByteString
@@ -631,6 +638,14 @@ spec = do
                                 Left err -> fail $ "JSON decode error: " ++ err
                                 Right entries ->
                                     length entries `shouldBe` 2
+                            let decodedJSON =
+                                    eitherDecode (simpleBody resp)
+                                        :: Either String [Value]
+                            liftIO $ case decodedJSON of
+                                Left err -> fail $ "JSON decode error: " ++ err
+                                Right entries ->
+                                    all (jsonObjectHasKey "slotNo") entries
+                                        `shouldBe` True
 
         describe "GET /proof/{txId}/{txIx}" $ do
             it "returns 404 for non-existent UTxO" $ do
@@ -702,7 +717,20 @@ spec = do
                             liftIO $ do
                                 proofBytes proof `shouldSatisfy` (not . T.null)
                                 proofTxOut proof `shouldSatisfy` (not . T.null)
-                                proofBlockHash proof `shouldSatisfy` (not . T.null)
+                                proofSlotNo proof `shouldBe` SlotNo 100
+                                encodeBase16Text
+                                    (renderHash $ proofBlockHash proof)
+                                    `shouldSatisfy` (not . T.null)
+                            let decodedProofJSON =
+                                    eitherDecode (simpleBody resp)
+                                        :: Either String Value
+                            liftIO $ case decodedProofJSON of
+                                Left err -> fail $ "JSON decode error: " ++ err
+                                Right proofJSON -> do
+                                    jsonObjectHasKey "slotNo" proofJSON
+                                        `shouldBe` True
+                                    jsonObjectHasKey "blockHash" proofJSON
+                                        `shouldBe` True
                             rootsResp <-
                                 request
                                     $ setPath

--- a/docs/assets/swagger.json
+++ b/docs/assets/swagger.json
@@ -23,13 +23,19 @@
             "type": "object"
         },
         "InclusionProofResponse": {
-            "description": "Inclusion proof, output, and block hash for the given transaction input.",
+            "description": "Inclusion proof, output, and chain point for the given transaction input.",
             "properties": {
                 "blockHash": {
                     "type": "string"
                 },
                 "proof": {
                     "type": "string"
+                },
+                "slotNo": {
+                    "format": "int64",
+                    "maximum": 1.8446744073709551615e19,
+                    "minimum": 0,
+                    "type": "integer"
                 },
                 "txOut": {
                     "type": "string"
@@ -38,6 +44,7 @@
             "required": [
                 "txOut",
                 "proof",
+                "slotNo",
                 "blockHash"
             ],
             "type": "object"
@@ -50,9 +57,16 @@
                 },
                 "merkleRoot": {
                     "type": "string"
+                },
+                "slotNo": {
+                    "format": "int64",
+                    "maximum": 1.8446744073709551615e19,
+                    "minimum": 0,
+                    "type": "integer"
                 }
             },
             "required": [
+                "slotNo",
                 "blockHash",
                 "merkleRoot"
             ],

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Slice gate for PR (#238). Present while in flight; dropped before mark-ready.
+set -euo pipefail
+cd "$(dirname "$0")"
+echo "== build cardano-utxo =="
+nix build --quiet .#cardano-utxo
+echo "== unit + database tests =="
+nix build --quiet .#unit-tests .#database-tests
+echo "GATE GREEN ($(date -Is))"

--- a/gate.sh
+++ b/gate.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# Slice gate for PR (#238). Present while in flight; dropped before mark-ready.
-set -euo pipefail
-cd "$(dirname "$0")"
-echo "== build cardano-utxo =="
-nix build --quiet .#cardano-utxo
-echo "== unit + database tests =="
-nix build --quiet .#unit-tests .#database-tests
-echo "GATE GREEN ($(date -Is))"

--- a/http/Cardano/UTxOCSMT/HTTP/API.hs
+++ b/http/Cardano/UTxOCSMT/HTTP/API.hs
@@ -18,6 +18,7 @@ module Cardano.UTxOCSMT.HTTP.API
     , API
     , DOCS
     , docs
+    , ChainPoint (..)
     , MerkleRootEntry (..)
     , InclusionProofResponse (..)
     , UTxOByAddressEntry (..)
@@ -31,7 +32,7 @@ import Cardano.UTxOCSMT.Application.Metrics (Metrics)
 import Cardano.UTxOCSMT.HTTP.Base16 (decodeBase16Text)
 import Control.Lens ((&), (.~), (?~))
 import Data.Aeson
-import Data.Aeson.Types (Parser)
+import Data.Aeson.Types (Pair, Parser)
 import Data.ByteArray.Encoding (Base (..), convertToBase)
 import Data.Proxy (Proxy (..))
 import Data.Swagger
@@ -46,6 +47,7 @@ import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
 import Data.Word (Word16, Word64)
 import GHC.IsList (IsList (..))
+import Ouroboros.Network.Block (SlotNo (..))
 import Servant
     ( Capture
     , Get
@@ -92,9 +94,17 @@ type API =
 api :: Proxy API
 api = Proxy
 
+-- | A Cardano chain point represented by slot number and block hash.
+data ChainPoint = ChainPoint
+    { chainPointSlotNo :: SlotNo
+    , chainPointBlockHash :: Hash
+    }
+    deriving (Show, Eq)
+
 -- | Entry for a merkle root at a given block
 data MerkleRootEntry = MerkleRootEntry
-    { blockHash :: Hash
+    { slotNo :: SlotNo
+    , blockHash :: Hash
     , merkleRoot :: Maybe Hash
     }
     deriving (Show, Eq)
@@ -102,7 +112,8 @@ data MerkleRootEntry = MerkleRootEntry
 data InclusionProofResponse = InclusionProofResponse
     { proofTxOut :: Text
     , proofBytes :: Text
-    , proofBlockHash :: Text
+    , proofSlotNo :: SlotNo
+    , proofBlockHash :: Hash
     }
     deriving (Show, Eq)
 
@@ -147,50 +158,101 @@ instance ToSchema UTxOByAddressEntry where
 renderHashBase16 :: Hash -> Text
 renderHashBase16 = Text.decodeUtf8 . convertToBase Base16 . renderHash
 
+parseHashBase16 :: Text -> Parser Hash
+parseHashBase16 txt =
+    case decodeBase16Text txt of
+        Left err -> fail $ "Invalid base16 hash: " ++ err
+        Right bs -> case parseHash bs of
+            Just h -> return h
+            Nothing ->
+                fail "Invalid hash length (expected 32 bytes)"
+
+chainPointFields :: ChainPoint -> [Pair]
+chainPointFields
+    ChainPoint
+        { chainPointSlotNo
+        , chainPointBlockHash
+        } =
+        [ "slotNo" .= unSlotNo chainPointSlotNo
+        , "blockHash" .= renderHashBase16 chainPointBlockHash
+        ]
+
+parseChainPoint :: Object -> Parser ChainPoint
+parseChainPoint v =
+    ChainPoint . SlotNo
+        <$> v .: "slotNo"
+        <*> (v .: "blockHash" >>= parseHashBase16)
+
+instance ToJSON ChainPoint where
+    toJSON = object . chainPointFields
+
+instance FromJSON ChainPoint where
+    parseJSON = withObject "ChainPoint" parseChainPoint
+
 instance ToJSON MerkleRootEntry where
-    toJSON MerkleRootEntry{blockHash, merkleRoot} =
+    toJSON MerkleRootEntry{slotNo, blockHash, merkleRoot} =
         object
-            [ "blockHash" .= renderHashBase16 blockHash
-            , "merkleRoot" .= fmap renderHashBase16 merkleRoot
-            ]
+            $ chainPointFields
+                ChainPoint{chainPointSlotNo = slotNo, chainPointBlockHash = blockHash}
+                <> [ "merkleRoot" .= fmap renderHashBase16 merkleRoot
+                   ]
 
 instance FromJSON MerkleRootEntry where
-    parseJSON = withObject "MerkleRootEntry" $ \v ->
+    parseJSON = withObject "MerkleRootEntry" $ \v -> do
+        ChainPoint{chainPointSlotNo, chainPointBlockHash} <-
+            parseChainPoint v
         MerkleRootEntry
-            <$> (v .: "blockHash" >>= parseHashBase16)
-            <*> (v .: "merkleRoot" >>= mapM parseHashBase16)
-      where
-        parseHashBase16 :: Text -> Parser Hash
-        parseHashBase16 txt =
-            case decodeBase16Text txt of
-                Left err -> fail $ "Invalid base16 hash: " ++ err
-                Right bs -> case parseHash bs of
-                    Just h -> return h
-                    Nothing ->
-                        fail "Invalid hash length (expected 32 bytes)"
+            chainPointSlotNo
+            chainPointBlockHash
+            <$> (v .: "merkleRoot" >>= mapM parseHashBase16)
 
 instance ToJSON InclusionProofResponse where
     toJSON
         InclusionProofResponse
             { proofTxOut
             , proofBytes
+            , proofSlotNo
             , proofBlockHash
             } =
             object
-                [ "txOut" .= proofTxOut
-                , "proof" .= proofBytes
-                , "blockHash" .= proofBlockHash
-                ]
+                $ [ "txOut" .= proofTxOut
+                  , "proof" .= proofBytes
+                  ]
+                    <> chainPointFields
+                        ChainPoint
+                            { chainPointSlotNo = proofSlotNo
+                            , chainPointBlockHash = proofBlockHash
+                            }
 
 instance FromJSON InclusionProofResponse where
-    parseJSON = withObject "InclusionProofResponse" $ \v ->
+    parseJSON = withObject "InclusionProofResponse" $ \v -> do
+        ChainPoint{chainPointSlotNo, chainPointBlockHash} <-
+            parseChainPoint v
         InclusionProofResponse
             <$> v .: "txOut"
             <*> v .: "proof"
-            <*> v .: "blockHash"
+            <*> pure chainPointSlotNo
+            <*> pure chainPointBlockHash
+
+instance ToSchema ChainPoint where
+    declareNamedSchema _ = do
+        stringSchema <- declareSchemaRef (Proxy @String)
+        word64Schema <- declareSchemaRef (Proxy @Word64)
+        return
+            $ Swagger.NamedSchema (Just "ChainPoint")
+            $ mempty
+            & Swagger.type_ ?~ Swagger.SwaggerObject
+            & properties
+                .~ fromList
+                    [ ("slotNo", word64Schema)
+                    , ("blockHash", stringSchema)
+                    ]
+            & required .~ ["slotNo", "blockHash"]
+            & description ?~ "A chain point with slot number and block hash."
 instance ToSchema MerkleRootEntry where
     declareNamedSchema _ = do
         stringSchema <- declareSchemaRef (Proxy @String)
+        word64Schema <- declareSchemaRef (Proxy @Word64)
         maybeStringSchema <- declareSchemaRef (Proxy @(Maybe String))
         return
             $ Swagger.NamedSchema (Just "MerkleRootEntry")
@@ -198,15 +260,17 @@ instance ToSchema MerkleRootEntry where
             & Swagger.type_ ?~ Swagger.SwaggerObject
             & properties
                 .~ fromList
-                    [ ("blockHash", stringSchema)
+                    [ ("slotNo", word64Schema)
+                    , ("blockHash", stringSchema)
                     , ("merkleRoot", maybeStringSchema)
                     ]
-            & required .~ ["blockHash", "merkleRoot"]
+            & required .~ ["slotNo", "blockHash", "merkleRoot"]
             & description ?~ "A merkle root at a given block"
 
 instance ToSchema InclusionProofResponse where
     declareNamedSchema _ = do
         stringSchema <- declareSchemaRef (Proxy @String)
+        word64Schema <- declareSchemaRef (Proxy @Word64)
         return
             $ Swagger.NamedSchema (Just "InclusionProofResponse")
             $ mempty
@@ -215,11 +279,12 @@ instance ToSchema InclusionProofResponse where
                 .~ fromList
                     [ ("txOut", stringSchema)
                     , ("proof", stringSchema)
+                    , ("slotNo", word64Schema)
                     , ("blockHash", stringSchema)
                     ]
-            & required .~ ["txOut", "proof", "blockHash"]
+            & required .~ ["txOut", "proof", "slotNo", "blockHash"]
             & description
-                ?~ "Inclusion proof, output, and block hash for the given transaction input."
+                ?~ "Inclusion proof, output, and chain point for the given transaction input."
 
 -- | Response for the /ready endpoint indicating sync status
 data ReadyResponse = ReadyResponse

--- a/specs/238-chainpoint-index/plan.md
+++ b/specs/238-chainpoint-index/plan.md
@@ -1,0 +1,26 @@
+# plan — #238
+
+## Tech stack
+Haskell (haskell.nix), `cardano-utxo-csmt` http + application packages. Gate:
+`nix build .#cardano-utxo .#unit-tests .#database-tests`.
+
+## Slice (one bisect-safe commit)
+
+### Slice 1 — restore the full chain point on both endpoints
+- Introduce a shared chain-point representation `{slotNo, blockHash}` (a `ChainPoint`
+  type, or restore `slotNo` symmetrically on both response types — driver's call,
+  but one shared shape).
+- `MerkleRootEntry`: add `slotNo :: SlotNo` back (c784375 had exactly this); thread
+  the already-available `slot` in `toMerkleRootEntry`. Update ToJSON/FromJSON/ToSchema.
+- Inclusion-proof response: carry the full chain point `{slotNo, blockHash}` instead
+  of the bare `proofBlockHash`; `queryInclusionProof` already has the full `Point`
+  (`pt`) — extract the slot too. Update ToJSON/FromJSON/ToSchema.
+- Update the `ServerSpec`/database-tests consumer (the #236 verify path) to the new
+  shapes; it may now match the root by `(slotNo, blockHash)`.
+- Update Swagger (`just update-swagger` if the CI swagger-drift check requires it).
+
+Single slice: the wire-type change + its (de)serialization + the test consumer are
+one coherent, bisect-safe unit.
+
+## Operator follow-up (not a code slice)
+Re-roll `utxo-csmt.plutimus.com` to the merged image (breaking wire change).

--- a/specs/238-chainpoint-index/spec.md
+++ b/specs/238-chainpoint-index/spec.md
@@ -1,0 +1,37 @@
+# spec — #238 key roots/proofs by full chain point (slot, blockHash)
+
+## P1 user story
+
+As a second-oracle consumer, I read `/merkle-roots` and an inclusion-proof response
+and get a full chain point `{slotNo, blockHash}` for each root, so I can index and
+order the 2160-root train by slot and resolve "the root as of slot X" without
+resolving hash→slot out of band.
+
+## Context
+
+`66ad3f1` moved root/proof addressing toward a chain point but represented it as a
+**bare block hash**, dropping `slotNo` from `MerkleRootEntry` and the inclusion-proof
+response. A Cardano chain point is `(slot, headerHash)`. The slot is already produced
+at both sites and discarded:
+- `queryMerkleRoots`/`toMerkleRootEntry (slot, blockHash, merkleRoot)` drops `slot`.
+- `queryInclusionProof` has the full `Point` (`pt`) but keeps only `slotHash pt`.
+
+This is additive plumbing, not new computation.
+
+## Functional requirements
+
+- FR1 — `MerkleRootEntry` carries `slotNo` again (with `blockHash`, `merkleRoot`).
+- FR2 — the inclusion-proof response carries the full chain point `{slotNo, blockHash}`.
+- FR3 — a single shared chain-point representation is used by both endpoints.
+- FR4 — JSON (de)serialization + Swagger schema match the new shapes.
+
+## Success criteria
+
+- `GET /merkle-roots` entries include `slotNo`.
+- `GET /proof/:txId/:txIx` carries `{slotNo, blockHash}` (a chain point), not a bare hash.
+- `database-tests` (incl. the #236 ServerSpec consumer-verify path) green.
+
+## Non-goals
+
+- No change to proof bytes / CSMT proof semantics — response **envelope** only.
+- Snapshot signing, HTTP exclusion proofs, on-chain anchor (separate follow-ups).

--- a/specs/238-chainpoint-index/tasks.md
+++ b/specs/238-chainpoint-index/tasks.md
@@ -1,0 +1,4 @@
+# tasks — #238
+
+## Slice 1 — restore the full chain point on both endpoints
+- [ ] T238-S1 Add a shared `{slotNo, blockHash}` chain-point shape; restore `slotNo` to `MerkleRootEntry` (thread the already-available slot in `toMerkleRootEntry`); carry the full chain point in the inclusion-proof response (extract slot from the `Point` in `queryInclusionProof`); update ToJSON/FromJSON/ToSchema + Swagger; update the #236 ServerSpec consumer; green `./gate.sh`.

--- a/specs/238-chainpoint-index/tasks.md
+++ b/specs/238-chainpoint-index/tasks.md
@@ -1,4 +1,4 @@
 # tasks — #238
 
 ## Slice 1 — restore the full chain point on both endpoints
-- [ ] T238-S1 Add a shared `{slotNo, blockHash}` chain-point shape; restore `slotNo` to `MerkleRootEntry` (thread the already-available slot in `toMerkleRootEntry`); carry the full chain point in the inclusion-proof response (extract slot from the `Point` in `queryInclusionProof`); update ToJSON/FromJSON/ToSchema + Swagger; update the #236 ServerSpec consumer; green `./gate.sh`.
+- [X] T238-S1 Add a shared `{slotNo, blockHash}` chain-point shape; restore `slotNo` to `MerkleRootEntry` (thread the already-available slot in `toMerkleRootEntry`); carry the full chain point in the inclusion-proof response (extract slot from the `Point` in `queryInclusionProof`); update ToJSON/FromJSON/ToSchema + Swagger; update the #236 ServerSpec consumer; green `./gate.sh`.


### PR DESCRIPTION
Closes #238.

Restores the canonical Cardano chain point `(slotNo, blockHash)` as the index for roots and proofs. `66ad3f1` moved toward chain-point addressing but represented it as a bare block hash, dropping `slotNo` from `MerkleRootEntry` and the inclusion-proof response. The slot is already produced and discarded at both sites — additive plumbing.

## Change
- `MerkleRootEntry` regains `slotNo`; `/merkle-roots` entries carry `{slotNo, blockHash, merkleRoot}`.
- Inclusion-proof response carries the full chain point `{slotNo, blockHash}`.
- One shared chain-point shape; JSON + Swagger updated; #236 ServerSpec verify path kept green.

## Non-goals
No change to proof bytes / CSMT semantics (envelope only). Signing / HTTP exclusion / on-chain anchor are separate.

Breaking wire change — preprod (`utxo-csmt.plutimus.com`) needs a re-roll after merge.